### PR TITLE
Add topology graph tab for project deployment visualization

### DIFF
--- a/Sources/OTClient/OTClient.swift
+++ b/Sources/OTClient/OTClient.swift
@@ -24,6 +24,7 @@ public struct OTClient: Sendable {
     public let token: String
     public let catalog: [CatalogEntry]
     public let region: String
+    public let project: String
 
     public static func connect(config: OTConfig, credentials: OTCredentials) async throws -> OTClient {
         var request = URLRequest(url: config.authURL.appending(path: "/auth/tokens"))
@@ -37,7 +38,7 @@ public struct OTClient: Sendable {
             throw OTError.authenticationFailed
         }
         let tokenResponse = try JSONDecoder().decode(TokenResponse.self, from: data)
-        return OTClient(token: token, catalog: tokenResponse.token.catalog, region: config.region)
+        return OTClient(token: token, catalog: tokenResponse.token.catalog, region: config.region, project: config.projectName)
     }
 
     // MARK: - Generic helpers
@@ -140,6 +141,31 @@ public struct OTClient: Sendable {
 
     public func deleteNetwork(id: String) async throws {
         try await requestVoid(service: "network", method: "DELETE", path: "/networks/\(id)", expected: 204)
+    }
+
+    public func listPorts() async throws -> [Port] {
+        let resp: PortListResponse = try await request(service: "network", method: "GET", path: "/ports", expected: 200)
+        return resp.ports
+    }
+
+    public func listSubnets() async throws -> [Subnet] {
+        let resp: SubnetListResponse = try await request(service: "network", method: "GET", path: "/subnets", expected: 200)
+        return resp.subnets
+    }
+
+    public func listRouters() async throws -> [Router] {
+        let resp: RouterListResponse = try await request(service: "network", method: "GET", path: "/routers", expected: 200)
+        return resp.routers
+    }
+
+    public func listFloatingIPs() async throws -> [FloatingIP] {
+        let resp: FloatingIPListResponse = try await request(service: "network", method: "GET", path: "/floatingips", expected: 200)
+        return resp.floatingips
+    }
+
+    public func listSecurityGroups() async throws -> [SecurityGroup] {
+        let resp: SecurityGroupListResponse = try await request(service: "network", method: "GET", path: "/security-groups", expected: 200)
+        return resp.securityGroups
     }
 
     // MARK: - Volumes (Cinder)
@@ -352,11 +378,106 @@ struct UpdateNetworkRequest: Encodable {
     let network: Payload
 }
 
+// MARK: Extended Network Models
+
+public struct Port: Decodable, Sendable {
+    public let id: String
+    public let name: String?
+    public let networkID: String
+    public let deviceID: String?
+    public let fixedIPs: [FixedIP]
+    public let securityGroups: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case id, name
+        case networkID = "network_id"
+        case deviceID = "device_id"
+        case fixedIPs = "fixed_ips"
+        case securityGroups = "security_groups"
+    }
+
+    public struct FixedIP: Decodable, Sendable {
+        public let subnetID: String
+        public let ipAddress: String
+
+        enum CodingKeys: String, CodingKey {
+            case subnetID = "subnet_id"
+            case ipAddress = "ip_address"
+        }
+    }
+}
+
+struct PortListResponse: Decodable {
+    let ports: [Port]
+}
+
+public struct Subnet: Decodable, Sendable {
+    public let id: String
+    public let name: String?
+    public let networkID: String
+
+    enum CodingKeys: String, CodingKey {
+        case id, name
+        case networkID = "network_id"
+    }
+}
+
+struct SubnetListResponse: Decodable {
+    let subnets: [Subnet]
+}
+
+public struct Router: Decodable, Sendable {
+    public let id: String
+    public let name: String?
+}
+
+struct RouterListResponse: Decodable {
+    let routers: [Router]
+}
+
+public struct FloatingIP: Decodable, Sendable {
+    public let id: String
+    public let floatingIPAddress: String
+    public let portID: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case floatingIPAddress = "floating_ip_address"
+        case portID = "port_id"
+    }
+}
+
+struct FloatingIPListResponse: Decodable {
+    let floatingips: [FloatingIP]
+}
+
+public struct SecurityGroup: Decodable, Sendable {
+    public let id: String
+    public let name: String
+}
+
+struct SecurityGroupListResponse: Decodable {
+    let securityGroups: [SecurityGroup]
+
+    enum CodingKeys: String, CodingKey {
+        case securityGroups = "security_groups"
+    }
+}
+
 // MARK: Volume Models
 
 public struct Volume: Decodable, Sendable {
     public let id: String
     public var name: String?
+    public let attachments: [Attachment]
+
+    public struct Attachment: Decodable, Sendable {
+        public let serverId: String?
+
+        enum CodingKeys: String, CodingKey {
+            case serverId = "server_id"
+        }
+    }
 }
 
 struct VolumeListResponse: Decodable {

--- a/Sources/otui/TUI.swift
+++ b/Sources/otui/TUI.swift
@@ -10,7 +10,7 @@ import CNCurses
 @MainActor
 final class TUI {
     enum Resource: CaseIterable {
-        case servers, networks, volumes, images
+        case servers, networks, volumes, images, topology
 
         var title: String {
             switch self {
@@ -18,6 +18,7 @@ final class TUI {
             case .networks: return "Networks"
             case .volumes: return "Volumes"
             case .images: return "Images"
+            case .topology: return "Topology"
             }
         }
     }
@@ -25,6 +26,8 @@ final class TUI {
     private let client: OTClient
     private var current: Resource = .servers
     private var running = true
+    private var scrollOffset = 0
+    private var lastTopology: TopologyGraph?
 
     init(client: OTClient) {
         self.client = client
@@ -46,12 +49,27 @@ final class TUI {
                 running = false
             case Int32(49): // 1
                 current = .servers
+                scrollOffset = 0
             case Int32(50): // 2
                 current = .networks
+                scrollOffset = 0
             case Int32(51): // 3
                 current = .volumes
+                scrollOffset = 0
             case Int32(52): // 4
                 current = .images
+                scrollOffset = 0
+            case Int32(53): // 5
+                current = .topology
+                scrollOffset = 0
+            case Int32(259): // KEY_UP
+                scrollOffset = max(scrollOffset - 1, 0)
+            case Int32(258): // KEY_DOWN
+                scrollOffset += 1
+            case Int32(119): // w
+                if current == .topology {
+                    await exportTopology()
+                }
             default:
                 break
             }
@@ -62,14 +80,19 @@ final class TUI {
     private func draw(screen: OpaquePointer?) async {
         werase(screen)
         let lines = await fetchLines()
+        let maxRows = 18
+        if scrollOffset > max(0, lines.count - maxRows) {
+            scrollOffset = max(0, lines.count - maxRows)
+        }
         wmove(screen, 0, 0)
         waddstr(screen, current.title)
-        for (idx, line) in lines.enumerated() {
+        for (idx, line) in lines.dropFirst(scrollOffset).prefix(maxRows).enumerated() {
             wmove(screen, Int32(idx + 1), 0)
             waddstr(screen, line)
         }
         wmove(screen, 20, 0)
-        waddstr(screen, "1 Servers 2 Networks 3 Volumes 4 Images | q Quit")
+        let footer = "1 Servers 2 Networks 3 Volumes 4 Images 5 Topology | q Quit"
+        waddstr(screen, footer)
         wrefresh(screen)
     }
 
@@ -87,6 +110,27 @@ final class TUI {
         case .images:
             let imgs = (try? await client.listImages()) ?? []
             return imgs.map { "\($0.name ?? "") \($0.id)" }
+        case .topology:
+            let graph = await TopologyGraphBuilder.build(client: client)
+            lastTopology = graph
+            return graph.lines
         }
+    }
+
+    private func exportTopology() async {
+        let graph: TopologyGraph
+        if let cached = lastTopology {
+            graph = cached
+        } else {
+            graph = await TopologyGraphBuilder.build(client: client)
+            lastTopology = graph
+        }
+        var header = "# Topology Graph\n"
+        header += "Region: \(client.region) Project: \(client.project)\n"
+        let c = graph.counts
+        header += "Totals: Servers \(c.servers) Networks \(c.networks) Subnets \(c.subnets) Ports \(c.ports) Routers \(c.routers) Volumes \(c.volumes) FIPs \(c.fips) SecurityGroups \(c.securityGroups)\n\n"
+        let body = graph.lines.joined(separator: "\n")
+        let content = header + body + "\n"
+        try? content.write(to: URL(fileURLWithPath: "topology.txt"), atomically: true, encoding: .utf8)
     }
 }

--- a/Sources/otui/TopologyGraph.swift
+++ b/Sources/otui/TopologyGraph.swift
@@ -1,0 +1,106 @@
+import Foundation
+import OTClient
+
+struct TopologyGraph: Sendable {
+    struct Counts: Sendable {
+        let servers: Int
+        let volumes: Int
+        let ports: Int
+        let networks: Int
+        let subnets: Int
+        let routers: Int
+        let fips: Int
+        let securityGroups: Int
+    }
+    let lines: [String]
+    let counts: Counts
+}
+
+enum TopologyGraphBuilder {
+    static func build(client: OTClient) async -> TopologyGraph {
+        async let serversReq = try? await client.listServers()
+        async let portsReq = try? await client.listPorts()
+        async let networksReq = try? await client.listNetworks()
+        async let subnetsReq = try? await client.listSubnets()
+        async let volumesReq = try? await client.listVolumes()
+        async let routersReq = try? await client.listRouters()
+        async let fipsReq = try? await client.listFloatingIPs()
+        async let sgsReq = try? await client.listSecurityGroups()
+
+        let servers = await serversReq ?? []
+        let ports = await portsReq ?? []
+        let networks = await networksReq ?? []
+        let subnets = await subnetsReq ?? []
+        let volumes = await volumesReq ?? []
+        let routers = await routersReq ?? []
+        let fips = await fipsReq ?? []
+        let sgs = await sgsReq ?? []
+
+        let networkByID = Dictionary(uniqueKeysWithValues: networks.map { ($0.id, $0) })
+        let subnetByID = Dictionary(uniqueKeysWithValues: subnets.map { ($0.id, $0) })
+        let sgByID = Dictionary(uniqueKeysWithValues: sgs.map { ($0.id, $0) })
+
+        var lines: [String] = []
+
+        for server in servers.sorted(by: { $0.name < $1.name }) {
+            lines.append("Server: \(server.name) (\(server.id))")
+            let sPorts = ports.filter { $0.deviceID == server.id }
+            for port in sPorts.sorted(by: { $0.id < $1.id }) {
+                lines.append("  Port: \(port.id)")
+                if let net = networkByID[port.networkID] {
+                    lines.append("    Network: \(net.name) (\(net.id))")
+                }
+                for ip in port.fixedIPs {
+                    if let subnet = subnetByID[ip.subnetID] {
+                        lines.append("    Subnet: \(subnet.name ?? "") (\(subnet.id))")
+                    }
+                }
+                for sgID in port.securityGroups {
+                    if let sg = sgByID[sgID] {
+                        lines.append("    SG: \(sg.name) (\(sg.id))")
+                    }
+                }
+                let pfips = fips.filter { $0.portID == port.id }
+                for f in pfips.sorted(by: { $0.floatingIPAddress < $1.floatingIPAddress }) {
+                    lines.append("    FIP: \(f.floatingIPAddress) (\(f.id))")
+                }
+            }
+            for volume in volumes.filter({ vol in vol.attachments.contains(where: { $0.serverId == server.id }) }).sorted(by: { ($0.name ?? "") < ($1.name ?? "") }) {
+                lines.append("  Volume: \(volume.name ?? "") (\(volume.id))")
+            }
+        }
+
+        for router in routers.sorted(by: { ($0.name ?? "") < ($1.name ?? "") }) {
+            lines.append("Router: \(router.name ?? "") (\(router.id))")
+            let rPorts = ports.filter { $0.deviceID == router.id }
+            for port in rPorts.sorted(by: { $0.id < $1.id }) {
+                lines.append("  Port: \(port.id)")
+                if let net = networkByID[port.networkID] {
+                    lines.append("    Network: \(net.name) (\(net.id))")
+                }
+                for ip in port.fixedIPs {
+                    if let subnet = subnetByID[ip.subnetID] {
+                        lines.append("    Subnet: \(subnet.name ?? "") (\(subnet.id))")
+                    }
+                }
+                let rfips = fips.filter { $0.portID == port.id }
+                for f in rfips.sorted(by: { $0.floatingIPAddress < $1.floatingIPAddress }) {
+                    lines.append("    FIP: \(f.floatingIPAddress) (\(f.id))")
+                }
+            }
+        }
+
+        let counts = TopologyGraph.Counts(
+            servers: servers.count,
+            volumes: volumes.count,
+            ports: ports.count,
+            networks: networks.count,
+            subnets: subnets.count,
+            routers: routers.count,
+            fips: fips.count,
+            securityGroups: sgs.count
+        )
+
+        return TopologyGraph(lines: lines, counts: counts)
+    }
+}

--- a/Tests/OTClientTests/OTClientTests.swift
+++ b/Tests/OTClientTests/OTClientTests.swift
@@ -9,4 +9,9 @@ final class OTClientTests: XCTestCase {
         XCTAssertEqual(config.region, "RegionOne")
         XCTAssertEqual(config.projectName, "demo")
     }
+
+    func testClientStoresProject() {
+        let client = OTClient(token: "t", catalog: [], region: "RegionOne", project: "demo")
+        XCTAssertEqual(client.project, "demo")
+    }
 }


### PR DESCRIPTION
## Summary
- extend OTClient with project tracking and additional network resources
- add scrollable Topology tab with ASCII export
- build topology graphs linking servers, networks, volumes, and more

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68c60d94f62483328de53c3e0a549986