### PR TITLE
Add search filtering and context banner to TUI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,6 +30,10 @@ let package = Package(
         .testTarget(
             name: "OTClientTests",
             dependencies: ["OTClient"]
+        ),
+        .testTarget(
+            name: "TUITests",
+            dependencies: ["otui"]
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ OTUI is an experimental terminal user interface for OpenStack written in Swift. 
 - Keystone authentication and service discovery
 - CRUD helpers for Nova servers, Neutron networks, Cinder volumes, and Glance images
 - Real-time terminal interface built with ncurses
+  - Persistent banner showing region and project
   - `1` Servers, `2` Networks, `3` Volumes, `4` Images, `5` Topology
+  - `/` Search current view (ESC to clear)
   - `w` Export topology (Topology tab), `q` Quit
 - Cross-platform support for Linux and macOS
 
@@ -44,7 +46,7 @@ Then start the TUI:
 swift run otui
 ```
 
-The interface refreshes every 200ms. Use the number keys to switch resources and `q` to quit.
+The interface refreshes every 200ms. Use the number keys to switch resources, `/` to search the current list, `ESC` to clear the search, and `q` to quit.
 
 ## Topology Graph
 The Topology tab (`5`) renders an ASCII map of the current project's deployment. It walks servers and routers to their attached ports, showing each port's network, subnet, security groups, floating IPs, and any volumes mounted to the server. Press `w` while viewing the tab to export the graph and resource totals to `topology.txt`.

--- a/Sources/otui/Filter.swift
+++ b/Sources/otui/Filter.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+func filterLines(_ lines: [String], query: String?) -> [String] {
+    guard let q = query, !q.isEmpty else { return lines }
+    return lines.filter { $0.range(of: q, options: .caseInsensitive) != nil }
+}

--- a/Sources/otui/TUI.swift
+++ b/Sources/otui/TUI.swift
@@ -28,6 +28,7 @@ final class TUI {
     private var running = true
     private var scrollOffset = 0
     private var lastTopology: TopologyGraph?
+    private var searchQuery: String?
 
     init(client: OTClient) {
         self.client = client
@@ -66,6 +67,15 @@ final class TUI {
                 scrollOffset = max(scrollOffset - 1, 0)
             case Int32(258): // KEY_DOWN
                 scrollOffset += 1
+            case Int32(47): // /
+                if let input = prompt("Search: ", screen: screen), !input.isEmpty {
+                    searchQuery = input
+                    scrollOffset = 0
+                } else {
+                    searchQuery = nil
+                }
+            case Int32(27): // ESC
+                searchQuery = nil
             case Int32(119): // w
                 if current == .topology {
                     await exportTopology()
@@ -85,13 +95,18 @@ final class TUI {
             scrollOffset = max(0, lines.count - maxRows)
         }
         wmove(screen, 0, 0)
-        waddstr(screen, current.title)
+        let banner = "Region: \(client.region) Project: \(client.project)"
+        waddstr(screen, banner)
+        wmove(screen, 1, 0)
+        var title = current.title
+        if let query = searchQuery { title += " [\(query)]" }
+        waddstr(screen, title)
         for (idx, line) in lines.dropFirst(scrollOffset).prefix(maxRows).enumerated() {
-            wmove(screen, Int32(idx + 1), 0)
+            wmove(screen, Int32(idx + 2), 0)
             waddstr(screen, line)
         }
-        wmove(screen, 20, 0)
-        let footer = "1 Servers 2 Networks 3 Volumes 4 Images 5 Topology | q Quit"
+        wmove(screen, 21, 0)
+        let footer = "1 Servers 2 Networks 3 Volumes 4 Images 5 Topology | / Search q Quit"
         waddstr(screen, footer)
         wrefresh(screen)
     }
@@ -100,21 +115,41 @@ final class TUI {
         switch current {
         case .servers:
             let servers = (try? await client.listServers()) ?? []
-            return servers.map { "\($0.name) \($0.id)" }
+            let lines = servers.map { "\($0.name) \($0.id)" }
+            return filterLines(lines, query: searchQuery)
         case .networks:
             let nets = (try? await client.listNetworks()) ?? []
-            return nets.map { "\($0.name) \($0.id)" }
+            let lines = nets.map { "\($0.name) \($0.id)" }
+            return filterLines(lines, query: searchQuery)
         case .volumes:
             let vols = (try? await client.listVolumes()) ?? []
-            return vols.map { "\($0.name ?? "") \($0.id)" }
+            let lines = vols.map { "\($0.name ?? "") \($0.id)" }
+            return filterLines(lines, query: searchQuery)
         case .images:
             let imgs = (try? await client.listImages()) ?? []
-            return imgs.map { "\($0.name ?? "") \($0.id)" }
+            let lines = imgs.map { "\($0.name ?? "") \($0.id)" }
+            return filterLines(lines, query: searchQuery)
         case .topology:
             let graph = await TopologyGraphBuilder.build(client: client)
             lastTopology = graph
-            return graph.lines
+            return filterLines(graph.lines, query: searchQuery)
         }
+    }
+
+    private func prompt(_ text: String, screen: OpaquePointer?) -> String? {
+        echo()
+        nodelay(screen, false)
+        defer {
+            noecho()
+            nodelay(screen, true)
+        }
+        wmove(screen, 22, 0)
+        wclrtoeol(screen)
+        waddstr(screen, text)
+        let buf = UnsafeMutablePointer<CChar>.allocate(capacity: 256)
+        defer { buf.deallocate() }
+        wgetnstr(screen, buf, 255)
+        return String(cString: buf)
     }
 
     private func exportTopology() async {

--- a/Tests/TUITests/TUITests.swift
+++ b/Tests/TUITests/TUITests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import otui
+
+final class TUITests: XCTestCase {
+    func testFilterLinesMatchesQuery() {
+        let lines = ["alpha", "beta", "gamma"]
+        let filtered = filterLines(lines, query: "ph")
+        XCTAssertEqual(filtered, ["alpha"])
+    }
+
+    func testFilterLinesNilReturnsAll() {
+        let lines = ["alpha", "beta"]
+        let filtered = filterLines(lines, query: nil)
+        XCTAssertEqual(filtered, lines)
+    }
+}


### PR DESCRIPTION
## Summary
- show current region and project in a persistent banner
- add `/` search filter with ESC to clear
- document new navigation features and add unit tests for filtering

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68c643d3a3f883329e423aeff3db8abb