### PR TITLE
feat: add day2 operations

### DIFF
--- a/Sources/OTClient/OTClient.swift
+++ b/Sources/OTClient/OTClient.swift
@@ -221,6 +221,51 @@ public struct OTClient: Sendable {
     public func deleteImage(id: String) async throws {
         try await requestVoid(service: "image", method: "DELETE", path: "/v2/images/\(id)", expected: 204)
     }
+
+    // MARK: - Day-2 Operations
+
+    public func startServer(id: String) async throws {
+        let body = try JSONSerialization.data(withJSONObject: ["os-start": NSNull()], options: [])
+        try await requestVoid(service: "compute", method: "POST", path: "/servers/\(id)/action", body: body, expected: 202)
+    }
+
+    public func stopServer(id: String) async throws {
+        let body = try JSONSerialization.data(withJSONObject: ["os-stop": NSNull()], options: [])
+        try await requestVoid(service: "compute", method: "POST", path: "/servers/\(id)/action", body: body, expected: 202)
+    }
+
+    public func attachPort(serverID: String, portID: String) async throws {
+        let payload = AttachPortRequest(interfaceAttachment: .init(portID: portID))
+        let data = try JSONEncoder().encode(payload)
+        try await requestVoid(service: "compute", method: "POST", path: "/servers/\(serverID)/os-interface", body: data, expected: 200)
+    }
+
+    public func createFloatingIP(networkID: String, portID: String? = nil) async throws -> FloatingIP {
+        let data = try JSONEncoder().encode(CreateFloatingIPRequest(floatingip: .init(floatingNetworkID: networkID, portID: portID)))
+        let resp: FloatingIPResponse = try await request(service: "network", method: "POST", path: "/floatingips", body: data, expected: 201)
+        return resp.floatingip
+    }
+
+    public func updateFloatingIP(id: String, portID: String?) async throws -> FloatingIP {
+        let data = try JSONEncoder().encode(UpdateFloatingIPRequest(floatingip: .init(portID: portID)))
+        let resp: FloatingIPResponse = try await request(service: "network", method: "PUT", path: "/floatingips/\(id)", body: data, expected: 200)
+        return resp.floatingip
+    }
+
+    public func deleteFloatingIP(id: String) async throws {
+        try await requestVoid(service: "network", method: "DELETE", path: "/floatingips/\(id)", expected: 204)
+    }
+
+    public func createSecurityGroupRule(securityGroupID: String, direction: String, protocol proto: String?, portRangeMin: Int?, portRangeMax: Int?, remoteIPPrefix: String?) async throws -> SecurityGroupRule {
+        let payload = CreateSecurityGroupRuleRequest(securityGroupRule: .init(securityGroupID: securityGroupID, direction: direction, protocol: proto, portRangeMin: portRangeMin, portRangeMax: portRangeMax, remoteIPPrefix: remoteIPPrefix))
+        let data = try JSONEncoder().encode(payload)
+        let resp: SecurityGroupRuleResponse = try await request(service: "network", method: "POST", path: "/security-group-rules", body: data, expected: 201)
+        return resp.securityGroupRule
+    }
+
+    public func deleteSecurityGroupRule(id: String) async throws {
+        try await requestVoid(service: "network", method: "DELETE", path: "/security-group-rules/\(id)", expected: 204)
+    }
 }
 
 public enum OTError: Error {
@@ -522,4 +567,95 @@ struct ImagePatch: Encodable {
     let op: String
     let path: String
     let value: String
+}
+
+// MARK: Day-2 Model Types
+
+struct AttachPortRequest: Encodable {
+    struct InterfaceAttachment: Encodable {
+        let portID: String
+
+        enum CodingKeys: String, CodingKey {
+            case portID = "port_id"
+        }
+    }
+    let interfaceAttachment: InterfaceAttachment
+}
+
+struct CreateFloatingIPRequest: Encodable {
+    struct Payload: Encodable {
+        let floatingNetworkID: String
+        let portID: String?
+
+        enum CodingKeys: String, CodingKey {
+            case floatingNetworkID = "floating_network_id"
+            case portID = "port_id"
+        }
+    }
+    let floatingip: Payload
+}
+
+struct UpdateFloatingIPRequest: Encodable {
+    struct Payload: Encodable {
+        let portID: String?
+
+        enum CodingKeys: String, CodingKey {
+            case portID = "port_id"
+        }
+    }
+    let floatingip: Payload
+}
+
+struct FloatingIPResponse: Decodable {
+    let floatingip: FloatingIP
+}
+
+public struct SecurityGroupRule: Decodable, Sendable {
+    public let id: String
+    public let direction: String
+    public let protocolType: String?
+    public let portRangeMin: Int?
+    public let portRangeMax: Int?
+    public let remoteIPPrefix: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, direction
+        case protocolType = "protocol"
+        case portRangeMin = "port_range_min"
+        case portRangeMax = "port_range_max"
+        case remoteIPPrefix = "remote_ip_prefix"
+    }
+}
+
+struct CreateSecurityGroupRuleRequest: Encodable {
+    struct Payload: Encodable {
+        let securityGroupID: String
+        let direction: String
+        let `protocol`: String?
+        let portRangeMin: Int?
+        let portRangeMax: Int?
+        let remoteIPPrefix: String?
+
+        enum CodingKeys: String, CodingKey {
+            case securityGroupID = "security_group_id"
+            case direction
+            case `protocol`
+            case portRangeMin = "port_range_min"
+            case portRangeMax = "port_range_max"
+            case remoteIPPrefix = "remote_ip_prefix"
+        }
+    }
+    let securityGroupRule: Payload
+
+    enum CodingKeys: String, CodingKey {
+        case securityGroupRule = "security_group_rule"
+    }
+}
+
+struct SecurityGroupRuleResponse: Decodable {
+    let securityGroupRule: SecurityGroupRule
+
+    enum CodingKeys: String, CodingKey {
+        case securityGroupRule = "security_group_rule"
+    }
 }

--- a/Sources/otui/TUI.swift
+++ b/Sources/otui/TUI.swift
@@ -29,6 +29,7 @@ final class TUI {
     private var scrollOffset = 0
     private var lastTopology: TopologyGraph?
     private var searchQuery: String?
+    private var statusMessage: String?
 
     init(client: OTClient) {
         self.client = client
@@ -80,6 +81,54 @@ final class TUI {
                 if current == .topology {
                     await exportTopology()
                 }
+            case Int32(111): // o start
+                if let id = prompt("Start server ID: ", screen: screen), !id.isEmpty {
+                    do { try await client.startServer(id: id); statusMessage = "Started \(id)" } catch { statusMessage = "Error \(error)" }
+                }
+            case Int32(112): // p stop
+                if let id = prompt("Stop server ID: ", screen: screen), !id.isEmpty {
+                    do { try await client.stopServer(id: id); statusMessage = "Stopped \(id)" } catch { statusMessage = "Error \(error)" }
+                }
+            case Int32(97): // a attach port
+                if let sid = prompt("Server ID: ", screen: screen),
+                   let pid = prompt("Port ID: ", screen: screen), !sid.isEmpty, !pid.isEmpty {
+                    do { try await client.attachPort(serverID: sid, portID: pid); statusMessage = "Attached port" } catch { statusMessage = "Error \(error)" }
+                }
+            case Int32(102): // f alloc fip
+                if let net = prompt("External network ID: ", screen: screen), !net.isEmpty {
+                    let port = prompt("Port ID (optional): ", screen: screen)
+                    do { let fip = try await client.createFloatingIP(networkID: net, portID: port?.isEmpty == true ? nil : port); statusMessage = "FIP \(fip.id)" } catch { statusMessage = "Error \(error)" }
+                }
+            case Int32(117): // u update fip
+                if let id = prompt("FIP ID: ", screen: screen), !id.isEmpty {
+                    let port = prompt("Port ID (blank to detach): ", screen: screen)
+                    do { _ = try await client.updateFloatingIP(id: id, portID: port?.isEmpty == true ? nil : port); statusMessage = "Updated FIP" } catch { statusMessage = "Error \(error)" }
+                }
+            case Int32(114): // r delete fip
+                if let id = prompt("Delete FIP ID: ", screen: screen), !id.isEmpty {
+                    do { try await client.deleteFloatingIP(id: id); statusMessage = "Deleted FIP" } catch { statusMessage = "Error \(error)" }
+                }
+            case Int32(103): // g add sg rule
+                if let sg = prompt("Security group ID: ", screen: screen), !sg.isEmpty,
+                   let dir = prompt("Direction (ingress/egress): ", screen: screen), !dir.isEmpty {
+                    let proto = prompt("Protocol (optional): ", screen: screen)
+                    let range = prompt("Port range min-max (optional): ", screen: screen)
+                    var min: Int?; var max: Int?
+                    if let r = range, !r.isEmpty {
+                        let parts = r.split(separator: "-")
+                        if let f = parts.first, let v = Int(f) { min = v }
+                        if parts.count > 1, let l = parts.last, let v = Int(l) { max = v }
+                    }
+                    let cidr = prompt("Remote IP prefix (optional): ", screen: screen)
+                    do {
+                        let rule = try await client.createSecurityGroupRule(securityGroupID: sg, direction: dir, protocol: proto?.isEmpty == true ? nil : proto, portRangeMin: min, portRangeMax: max, remoteIPPrefix: cidr?.isEmpty == true ? nil : cidr)
+                        statusMessage = "Rule \(rule.id)"
+                    } catch { statusMessage = "Error \(error)" }
+                }
+            case Int32(100): // d delete sg rule
+                if let rid = prompt("Rule ID: ", screen: screen), !rid.isEmpty {
+                    do { try await client.deleteSecurityGroupRule(id: rid); statusMessage = "Deleted rule" } catch { statusMessage = "Error \(error)" }
+                }
             default:
                 break
             }
@@ -105,8 +154,13 @@ final class TUI {
             wmove(screen, Int32(idx + 2), 0)
             waddstr(screen, line)
         }
+        if let status = statusMessage {
+            wmove(screen, 20, 0)
+            wclrtoeol(screen)
+            waddstr(screen, status)
+        }
         wmove(screen, 21, 0)
-        let footer = "1 Servers 2 Networks 3 Volumes 4 Images 5 Topology | / Search q Quit"
+        let footer = "1 Servers 2 Networks 3 Volumes 4 Images 5 Topology | o start p stop a attach f newFIP u updFIP r delFIP g addRule d delRule / Search q Quit"
         waddstr(screen, footer)
         wrefresh(screen)
     }


### PR DESCRIPTION
## Summary
- extend OTClient with start/stop server, port attach, floating IP, and security group rule APIs
- wire TUI to trigger day-2 operations with key bindings and show status messages

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68c6471036c883328a3a0d75421f597d