### PR TITLE
Fix TUI initialization and update tests

### DIFF
--- a/Sources/otui/TUI.swift
+++ b/Sources/otui/TUI.swift
@@ -43,8 +43,10 @@ final class TUI {
         nodelay(screen, true)
         defer { endwin() }
 
+        // Draw once so the user sees the interface immediately
+        await draw(screen: screen)
+
         while running {
-            await draw(screen: screen)
             let ch = wgetch(screen)
             switch ch {
             case Int32(113): // q
@@ -132,17 +134,14 @@ final class TUI {
             default:
                 break
             }
+            if !running { break }
+            await draw(screen: screen)
             usleep(200_000) // 200ms refresh
         }
     }
 
     private func draw(screen: OpaquePointer?) async {
         werase(screen)
-        let lines = await fetchLines()
-        let maxRows = 18
-        if scrollOffset > max(0, lines.count - maxRows) {
-            scrollOffset = max(0, lines.count - maxRows)
-        }
         wmove(screen, 0, 0)
         let banner = "Region: \(client.region) Project: \(client.project)"
         waddstr(screen, banner)
@@ -150,6 +149,14 @@ final class TUI {
         var title = current.title
         if let query = searchQuery { title += " [\(query)]" }
         waddstr(screen, title)
+        // Refresh early so the banner is visible while data loads
+        wrefresh(screen)
+
+        let lines = await fetchLines()
+        let maxRows = 18
+        if scrollOffset > max(0, lines.count - maxRows) {
+            scrollOffset = max(0, lines.count - maxRows)
+        }
         for (idx, line) in lines.dropFirst(scrollOffset).prefix(maxRows).enumerated() {
             wmove(screen, Int32(idx + 2), 0)
             waddstr(screen, line)

--- a/Tests/OTClientTests/OTClientTests.swift
+++ b/Tests/OTClientTests/OTClientTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class OTClientTests: XCTestCase {
     func testConfigInit() throws {
         let url = URL(string: "https://example.com/v3")!
-        let config = OTConfig(authURL: url, region: "RegionOne", projectName: "demo")
+        let config = OTConfig(authURL: url, region: "RegionOne", projectName: "demo", projectDomain: "Default")
         XCTAssertEqual(config.authURL, url)
         XCTAssertEqual(config.region, "RegionOne")
         XCTAssertEqual(config.projectName, "demo")


### PR DESCRIPTION
## Summary
- render initial TUI screen and process input before fetching data
- display header while data loads to avoid blank screen
- adjust tests for OTConfig projectDomain parameter

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68c653e08e948332a4d1a90a06dbf28a