### PR TITLE
fix: Ensure that the osclient config parser doesn't crash

### DIFF
--- a/Sources/Substation/App.swift
+++ b/Sources/Substation/App.swift
@@ -418,11 +418,22 @@ struct Substation {
         let configManager = CloudConfigManager()
         do {
             Logger.shared.logDebug("Listing available clouds")
-            let clouds = try await configManager.listAvailableClouds(path: configPath)
+            let cloudsConfig = try await configManager.loadCloudsConfig(path: configPath)
+            let clouds = Array(cloudsConfig.clouds.keys).sorted()
             Logger.shared.logInfo("Found \(clouds.count) clouds in configuration")
+
+            // Display validation warnings first, if any
+            if !cloudsConfig.validationWarnings.isEmpty {
+                print("Configuration Warnings:")
+                for (cloudName, warning) in cloudsConfig.validationWarnings.sorted(by: { $0.key < $1.key }) {
+                    print("  \(cloudName): \(warning) [SKIPPED]")
+                }
+                print("")
+            }
+
             if clouds.isEmpty {
-                Logger.shared.logWarning("No clouds found in configuration")
-                print("No clouds found in configuration.")
+                Logger.shared.logWarning("No valid clouds found in configuration")
+                print("No valid clouds found in configuration.")
                 return
             }
 

--- a/Sources/Substation/CloudConfig.swift
+++ b/Sources/Substation/CloudConfig.swift
@@ -57,9 +57,26 @@ public enum RegionConfig: Codable, Sendable {
 
 public struct CloudsConfig: Codable, Sendable {
     public let clouds: [String: CloudConfig]
+    public let validationWarnings: [String: String]
 
-    public init(clouds: [String: CloudConfig]) {
+    public init(clouds: [String: CloudConfig], validationWarnings: [String: String] = [:]) {
         self.clouds = clouds
+        self.validationWarnings = validationWarnings
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case clouds
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        clouds = try container.decode([String: CloudConfig].self, forKey: .clouds)
+        validationWarnings = [:]
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(clouds, forKey: .clouds)
     }
 }
 

--- a/Sources/Substation/EnhancedCloudConfig.swift
+++ b/Sources/Substation/EnhancedCloudConfig.swift
@@ -269,6 +269,7 @@ public actor EnhancedYAMLParser {
         }
 
         var clouds: [String: CloudConfig] = [:]
+        var validationWarnings: [String: String] = [:]
         let lines = yamlString.components(separatedBy: .newlines)
 
         var currentCloud: String?
@@ -315,11 +316,17 @@ public actor EnhancedYAMLParser {
             if indent == 2 && trimmedLine.hasSuffix(":") && state.canTransitionToNewCloud {
                 // Save previous cloud if exists
                 if let cloudName = currentCloud {
-                    clouds[cloudName] = try await createCloudConfig(
-                        from: currentConfig,
-                        auth: currentAuth,
-                        regions: currentRegions
-                    )
+                    do {
+                        clouds[cloudName] = try await createCloudConfig(
+                            from: currentConfig,
+                            auth: currentAuth,
+                            regions: currentRegions
+                        )
+                    } catch CloudConfigError.missingRequiredField(let field) {
+                        // Skip this cloud configuration if it's missing required fields
+                        // Add a validation warning so users can see what went wrong
+                        validationWarnings[cloudName] = "Missing required field: \(field)"
+                    }
                 }
 
                 // Start new cloud
@@ -418,14 +425,20 @@ public actor EnhancedYAMLParser {
 
         // Save the last cloud
         if let cloudName = currentCloud {
-            clouds[cloudName] = try await createCloudConfig(
-                from: currentConfig,
-                auth: currentAuth,
-                regions: currentRegions
-            )
+            do {
+                clouds[cloudName] = try await createCloudConfig(
+                    from: currentConfig,
+                    auth: currentAuth,
+                    regions: currentRegions
+                )
+            } catch CloudConfigError.missingRequiredField(let field) {
+                // Skip this cloud configuration if it's missing required fields
+                // Add a validation warning so users can see what went wrong
+                validationWarnings[cloudName] = "Missing required field: \(field)"
+            }
         }
 
-        return CloudsConfig(clouds: clouds)
+        return CloudsConfig(clouds: clouds, validationWarnings: validationWarnings)
     }
 
     private func parseKeyValue(_ line: String) async -> (String, String) {

--- a/Tests/SubstationTests/EnhancedCloudConfigTests.swift
+++ b/Tests/SubstationTests/EnhancedCloudConfigTests.swift
@@ -447,6 +447,58 @@ final class EnhancedCloudConfigTests: XCTestCase {
         }
     }
 
+    // MARK: - Error Handling Tests
+
+    func testSkipCloudWithMissingRequiredField() async throws {
+        let yamlContent = """
+        clouds:
+          valid-cloud:
+            auth:
+              auth_url: https://identity.example.com/v3
+              username: testuser
+              password: testpass
+              project_name: testproject
+            region_name: RegionOne
+          invalid-cloud:
+            auth:
+              username: testuser
+              password: testpass
+              project_name: testproject
+            region_name: RegionTwo
+          another-valid-cloud:
+            auth:
+              auth_url: https://identity2.example.com/v3
+              application_credential_id: abc123
+              application_credential_secret: secret456
+              project_name: myproject
+            region_name: RegionThree
+        """
+
+        let parser = EnhancedYAMLParser()
+        let data = yamlContent.data(using: .utf8)!
+        let config = try await parser.parse(data)
+
+        // Verify that only valid clouds were loaded
+        XCTAssertEqual(config.clouds.count, 2)
+        XCTAssertNotNil(config.clouds["valid-cloud"])
+        XCTAssertNotNil(config.clouds["another-valid-cloud"])
+        XCTAssertNil(config.clouds["invalid-cloud"])
+
+        // Verify that validation warnings were recorded for invalid cloud
+        XCTAssertEqual(config.validationWarnings.count, 1)
+        XCTAssertNotNil(config.validationWarnings["invalid-cloud"])
+        XCTAssertTrue(config.validationWarnings["invalid-cloud"]?.contains("auth_url") ?? false)
+
+        // Verify the valid clouds have correct data
+        let validCloud = config.clouds["valid-cloud"]!
+        XCTAssertEqual(validCloud.auth.auth_url, "https://identity.example.com/v3")
+        XCTAssertEqual(validCloud.auth.username, "testuser")
+
+        let anotherValidCloud = config.clouds["another-valid-cloud"]!
+        XCTAssertEqual(anotherValidCloud.auth.auth_url, "https://identity2.example.com/v3")
+        XCTAssertEqual(anotherValidCloud.auth.application_credential_id, "abc123")
+    }
+
     // MARK: - Performance Tests
 
     func testParsingPerformance() async throws {


### PR DESCRIPTION
Before this fix, if a clouds.yaml had an invlaid entry within it, the config parser would simply return an error showing the missing field. This change will now pull entries out of the available options and provide warnings about them instead of halting and sending the user on a goose chase.

Related-Issue: https://github.com/cloudnull/substation/issues/11