### PR TITLE
feat: add region auto-detect

### DIFF
--- a/Sources/Substation/App.swift
+++ b/Sources/Substation/App.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import OSClient
 import MemoryKit
 
@@ -212,14 +215,25 @@ struct Substation {
             authURL.appendPathComponent("v3")
         }
 
-        // Use primary region from config, fallback to common defaults, with validation
-        let region = cloudConfig.primaryRegionName ?? "RegionOne"
-        Logger.shared.logDebug("Using region: \(region)")
-        if region.isEmpty {
-            Logger.shared.logError("Invalid region configuration: region_name cannot be empty")
-            printError("Invalid region configuration: region_name cannot be empty")
-            exit(1)
+        // Handle region configuration
+        let region: String?
+        var needsRegionDetection = false
+
+        if let configuredRegion = cloudConfig.primaryRegionName {
+            if configuredRegion.isEmpty {
+                Logger.shared.logError("Invalid region configuration: region_name cannot be empty")
+                printError("Invalid region configuration: region_name cannot be empty")
+                exit(1)
+            }
+            region = configuredRegion
+            Logger.shared.logDebug("Using configured region: \(configuredRegion)")
+        } else {
+            // Region not specified - will need to detect from service catalog
+            Logger.shared.logDebug("No region specified in configuration - will auto-detect from service catalog")
+            region = nil
+            needsRegionDetection = true
         }
+
         let interface = cloudConfig.interface ?? "public"
         Logger.shared.logDebug("Using interface: \(interface)")
 
@@ -261,7 +275,7 @@ struct Substation {
 
         let config = OTConfig(
             authURL: authURL,
-            region: region,
+            region: region ?? "auto-detect",
             userDomainName: userDomain,
             projectDomainName: projectDomain
         )
@@ -340,7 +354,7 @@ struct Substation {
 
             Logger.shared.logStartup("Application starting with cloud: \(selectedCloud)")
             Logger.shared.logInfo("Auth URL: \(authURL)")
-            Logger.shared.logInfo("Region: \(region)")
+            Logger.shared.logInfo("Region: \(region ?? "auto-detect")")
             Logger.shared.logInfo("Interface: \(interface)")
             Logger.shared.logInfo("Project domain: \(projectDomain)")
             Logger.shared.logInfo("User domain: \(userDomain)")
@@ -367,10 +381,27 @@ struct Substation {
             Logger.shared.logInfo("Connecting to OpenStack cloud '\(selectedCloud)'")
 
             let connectionStart = Date().timeIntervalSinceReferenceDate
-            let client = try await OSClient.connect(config: config, credentials: credentials, logger: LoggerBridge())
+            var client = try await OSClient.connect(config: config, credentials: credentials, logger: LoggerBridge())
             let connectionDuration = Date().timeIntervalSinceReferenceDate - connectionStart
             Logger.shared.logPerformance("OpenStack client connection", duration: connectionDuration)
             Logger.shared.logInfo("Successfully connected to OpenStack cloud")
+
+            // Auto-detect region if not specified in configuration
+            if needsRegionDetection {
+                Logger.shared.logInfo("Auto-detecting region from service catalog")
+                let detectedRegion = try await detectRegionFromCatalog(client: client, authURL: authURL, credentials: credentials, config: config)
+                Logger.shared.logInfo("Detected region: \(detectedRegion)")
+
+                // Reconnect with the detected region
+                let reconnectConfig = OTConfig(
+                    authURL: authURL,
+                    region: detectedRegion,
+                    userDomainName: config.userDomainName,
+                    projectDomainName: config.projectDomainName
+                )
+                client = try await OSClient.connect(config: reconnectConfig, credentials: credentials, logger: LoggerBridge())
+                Logger.shared.logInfo("Reconnected with detected region: \(detectedRegion)")
+            }
 
             Logger.shared.logDebug("Initializing TUI")
             let tui = try await TUI(client: client, debugMode: debugMode, sharedLogger: sharedLogger)
@@ -389,7 +420,7 @@ struct Substation {
 
             Current configuration:
             - Cloud: \(selectedCloud)
-            - Region: '\(region)' (verify this exists in your OpenStack deployment)
+            - Region: '\(region ?? "auto-detect")' (verify this exists in your OpenStack deployment)
             - Interface: '\(interface)' (try 'public', 'internal', or 'admin')
             - Auth URL: \(authURL)
 
@@ -409,6 +440,127 @@ struct Substation {
         } catch {
             let errorMsg = "Connection error: \(error)"
             Logger.shared.logError("Connection failed", error: error)
+            printError(errorMsg)
+            exit(1)
+        }
+    }
+
+    // Helper structures for token response parsing
+    private struct TokenResponse: Codable {
+        let token: TokenData
+    }
+
+    private struct TokenData: Codable {
+        let catalog: [TokenCatalogEntry]?
+    }
+
+    private static func buildAuthRequest(credentials: OTCredentials) throws -> [String: Any] {
+        switch credentials {
+        case .password(let username, let password, let projectName, let userDomain, let projectDomain):
+            return [
+                "auth": [
+                    "identity": [
+                        "methods": ["password"],
+                        "password": [
+                            "user": [
+                                "name": username,
+                                "password": password,
+                                "domain": ["name": userDomain]
+                            ]
+                        ]
+                    ],
+                    "scope": [
+                        "project": [
+                            "name": projectName,
+                            "domain": ["name": projectDomain]
+                        ]
+                    ]
+                ]
+            ]
+        case .applicationCredential(let id, let secret, let projectName):
+            var authDict: [String: Any] = [
+                "auth": [
+                    "identity": [
+                        "methods": ["application_credential"],
+                        "application_credential": [
+                            "id": id,
+                            "secret": secret
+                        ]
+                    ]
+                ]
+            ]
+            if !projectName.isEmpty {
+                authDict["auth"] = [
+                    "identity": authDict["auth"]!,
+                    "scope": [
+                        "project": ["name": projectName]
+                    ]
+                ]
+            }
+            return authDict
+        }
+    }
+
+    static func detectRegionFromCatalog(
+        client: OSClient,
+        authURL: URL,
+        credentials: OTCredentials,
+        config: OTConfig
+    ) async throws -> String {
+        // Perform a raw authentication request to get the token catalog
+        // This bypasses the client's service catalog building which requires a region
+        let authRequest = try buildAuthRequest(credentials: credentials)
+
+        var request = URLRequest(url: authURL.appendingPathComponent("auth/tokens"))
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: authRequest, options: [])
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 201 else {
+            throw OTError.authenticationFailed
+        }
+
+        // Parse the auth response to get the catalog
+        let authResponse = try JSONDecoder().decode(TokenResponse.self, from: data)
+
+        // Extract unique regions from all endpoints in the catalog
+        var regions = Set<String>()
+        for service in authResponse.token.catalog ?? [] {
+            for endpoint in service.endpoints {
+                if let region = endpoint.region, !region.isEmpty {
+                    regions.insert(region)
+                }
+            }
+        }
+
+        let sortedRegions = regions.sorted()
+
+        if sortedRegions.isEmpty {
+            Logger.shared.logError("No regions found in service catalog")
+            printError("No regions found in service catalog. Please configure a region_name in your clouds.yaml")
+            exit(1)
+        } else if sortedRegions.count == 1 {
+            Logger.shared.logInfo("Auto-detected single region: \(sortedRegions[0])")
+            return sortedRegions[0]
+        } else {
+            // Multiple regions detected - user must specify
+            let regionList = sortedRegions.joined(separator: ", ")
+            let errorMsg = """
+
+            Multiple regions detected in service catalog: \(regionList)
+
+            Please update your clouds.yaml configuration to specify which region to use.
+            Add the 'region_name' field to your cloud configuration:
+
+            clouds:
+              your-cloud-name:
+                region_name: <one of: \(regionList)>
+                ...
+
+            """
+            Logger.shared.logError("Multiple regions detected but no region_name configured")
             printError(errorMsg)
             exit(1)
         }

--- a/Tests/SubstationTests/EnhancedCloudConfigTests.swift
+++ b/Tests/SubstationTests/EnhancedCloudConfigTests.swift
@@ -499,6 +499,132 @@ final class EnhancedCloudConfigTests: XCTestCase {
         XCTAssertEqual(anotherValidCloud.auth.application_credential_id, "abc123")
     }
 
+    // MARK: - Region Auto-Detection Tests
+    //
+    // These tests verify that clouds.yaml configurations without region_name
+    // are parsed correctly, allowing the application to auto-detect regions
+    // from the service catalog at runtime.
+
+    func testRegionAutoDetectionWithNoRegion() async throws {
+        let yamlContent = """
+        clouds:
+          cloud-no-region:
+            auth:
+              auth_url: https://identity.example.com/v3
+              username: testuser
+              password: testpass
+              project_name: testproject
+              user_domain_name: Default
+              project_domain_name: Default
+            interface: public
+        """
+
+        let parser = EnhancedYAMLParser()
+        let data = yamlContent.data(using: .utf8)!
+        let config = try await parser.parse(data)
+
+        // Verify cloud was loaded successfully
+        XCTAssertEqual(config.clouds.count, 1)
+        XCTAssertNotNil(config.clouds["cloud-no-region"])
+
+        let cloud = config.clouds["cloud-no-region"]!
+
+        // Verify region_name is nil (allowing auto-detection)
+        XCTAssertNil(cloud.region_name)
+        XCTAssertNil(cloud.primaryRegionName)
+
+        // Verify other fields are properly configured
+        XCTAssertEqual(cloud.auth.auth_url, "https://identity.example.com/v3")
+        XCTAssertEqual(cloud.auth.username, "testuser")
+        XCTAssertEqual(cloud.auth.project_name, "testproject")
+        XCTAssertEqual(cloud.interface, "public")
+    }
+
+    func testRegionAutoDetectionWithEmptyString() async throws {
+        let yamlContent = """
+        clouds:
+          cloud-empty-region:
+            auth:
+              auth_url: https://identity.example.com/v3
+              username: testuser
+              password: testpass
+              project_name: testproject
+              user_domain_name: Default
+              project_domain_name: Default
+            region_name: ""
+            interface: public
+        """
+
+        let parser = EnhancedYAMLParser()
+        let data = yamlContent.data(using: .utf8)!
+        let config = try await parser.parse(data)
+
+        XCTAssertEqual(config.clouds.count, 1)
+        let cloud = config.clouds["cloud-empty-region"]!
+
+        // Empty string should result in nil primaryRegionName
+        XCTAssertNil(cloud.primaryRegionName)
+    }
+
+    func testRegionConfigurationVariations() async throws {
+        let yamlContent = """
+        clouds:
+          cloud-with-single-region:
+            auth:
+              auth_url: https://identity1.example.com/v3
+              username: user1
+              password: pass1
+              project_name: project1
+              user_domain_name: Default
+              project_domain_name: Default
+            region_name: RegionOne
+            interface: public
+          cloud-with-multiple-regions:
+            auth:
+              auth_url: https://identity2.example.com/v3
+              username: user2
+              password: pass2
+              project_name: project2
+              user_domain_name: Default
+              project_domain_name: Default
+            region_name:
+              - RegionOne
+              - RegionTwo
+              - RegionThree
+            interface: public
+          cloud-with-no-region:
+            auth:
+              auth_url: https://identity3.example.com/v3
+              username: user3
+              password: pass3
+              project_name: project3
+              user_domain_name: Default
+              project_domain_name: Default
+            interface: public
+        """
+
+        let parser = EnhancedYAMLParser()
+        let data = yamlContent.data(using: .utf8)!
+        let config = try await parser.parse(data)
+
+        XCTAssertEqual(config.clouds.count, 3)
+
+        // Test single region
+        let singleRegion = config.clouds["cloud-with-single-region"]!
+        XCTAssertEqual(singleRegion.primaryRegionName, "RegionOne")
+        XCTAssertEqual(singleRegion.allRegionNames, ["RegionOne"])
+
+        // Test multiple regions (should use first as primary)
+        let multiRegion = config.clouds["cloud-with-multiple-regions"]!
+        XCTAssertEqual(multiRegion.primaryRegionName, "RegionOne")
+        XCTAssertEqual(multiRegion.allRegionNames, ["RegionOne", "RegionTwo", "RegionThree"])
+
+        // Test no region (should be nil for auto-detection)
+        let noRegion = config.clouds["cloud-with-no-region"]!
+        XCTAssertNil(noRegion.primaryRegionName)
+        XCTAssertEqual(noRegion.allRegionNames, [])
+    }
+
     // MARK: - Performance Tests
 
     func testParsingPerformance() async throws {

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -303,35 +303,6 @@ clouds:
     cacert: /path/to/ca.pem   # Custom CA certificate
 ```
 
-### Environment Variables
-
-Alternatively, use environment variables (compatible with OpenStack CLI):
-
-```bash
-# Authentication
-export OS_AUTH_URL=https://openstack.example.com:5000/v3
-export OS_USERNAME=operator
-export OS_PASSWORD=secret
-export OS_PROJECT_NAME=operations
-export OS_PROJECT_DOMAIN_NAME=default
-export OS_USER_DOMAIN_NAME=default
-export OS_REGION_NAME=RegionOne
-
-# Run Substation
-substation
-```
-
-**Application Credential Variables:**
-
-```bash
-export OS_AUTH_URL=https://openstack.example.com:5000/v3
-export OS_APPLICATION_CREDENTIAL_ID=abc123...
-export OS_APPLICATION_CREDENTIAL_SECRET=secret456...
-export OS_REGION_NAME=RegionOne
-
-substation
-```
-
 ### Testing Your Configuration
 
 **Test Connection:**


### PR DESCRIPTION
This change will allow substation to auto-detect the region if no region is defined. If more than one region is returned as part of the auth catalog an error will be raised instructing the user to set the region_name value in their configuration file.

Related-Issue: https://github.com/cloudnull/substation/issues/11