### PR TITLE
feat: add bulk operations for multi-select

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ Substation is built as a modular Swift package (because monoliths are so 2010):
 - **`CrossPlatformTimer`**: Cross-platform timer utilities - Because macOS and Linux can't agree on anything
 - **`Substation`**: Main executable combining all components - Where the magic happens
 
-**Zero external dependencies** - We built it all ourselves. Every. Single. Line.
-
 ## Quick Start in 1 minute
 
 ### Get the container

--- a/Sources/Substation/BatchOperations/BatchOperationManager.swift
+++ b/Sources/Substation/BatchOperations/BatchOperationManager.swift
@@ -402,6 +402,38 @@ actor BatchOperationManager {
                 try await executeNetworkInterfaceAttach(operation, execution: execution)
                 resourceID = operation.resourceIdentifier
 
+            case (.subnet, .delete):
+                try await executeSubnetDelete(operation, execution: execution)
+                resourceID = operation.resourceIdentifier
+
+            case (.router, .delete):
+                try await executeRouterDelete(operation, execution: execution)
+                resourceID = operation.resourceIdentifier
+
+            case (.port, .delete):
+                try await executePortDelete(operation, execution: execution)
+                resourceID = operation.resourceIdentifier
+
+            case (.floatingIP, .delete):
+                try await executeFloatingIPDelete(operation, execution: execution)
+                resourceID = operation.resourceIdentifier
+
+            case (.securityGroup, .delete):
+                try await executeSecurityGroupDelete(operation, execution: execution)
+                resourceID = operation.resourceIdentifier
+
+            case (.serverGroup, .delete):
+                try await executeServerGroupDelete(operation, execution: execution)
+                resourceID = operation.resourceIdentifier
+
+            case (.keyPair, .delete):
+                try await executeKeyPairDelete(operation, execution: execution)
+                resourceID = operation.resourceIdentifier
+
+            case (.image, .delete):
+                try await executeImageDelete(operation, execution: execution)
+                resourceID = operation.resourceIdentifier
+
             default:
                 throw BatchOperationError.executionFailed("Unsupported operation: \(operation.action.rawValue) \(operation.type.rawValue)")
             }
@@ -662,6 +694,62 @@ actor BatchOperationManager {
             serverID: serverID,
             networkID: networkID
         )
+    }
+
+    private func executeSubnetDelete(
+        _ operation: ResourceDependencyResolver.PlannedOperation,
+        execution: BatchOperationExecution
+    ) async throws {
+        try await client.deleteSubnet(id: operation.resourceIdentifier)
+    }
+
+    private func executeRouterDelete(
+        _ operation: ResourceDependencyResolver.PlannedOperation,
+        execution: BatchOperationExecution
+    ) async throws {
+        try await client.deleteRouter(id: operation.resourceIdentifier)
+    }
+
+    private func executePortDelete(
+        _ operation: ResourceDependencyResolver.PlannedOperation,
+        execution: BatchOperationExecution
+    ) async throws {
+        try await client.deletePort(id: operation.resourceIdentifier)
+    }
+
+    private func executeFloatingIPDelete(
+        _ operation: ResourceDependencyResolver.PlannedOperation,
+        execution: BatchOperationExecution
+    ) async throws {
+        try await client.deleteFloatingIP(id: operation.resourceIdentifier)
+    }
+
+    private func executeSecurityGroupDelete(
+        _ operation: ResourceDependencyResolver.PlannedOperation,
+        execution: BatchOperationExecution
+    ) async throws {
+        try await client.deleteSecurityGroup(id: operation.resourceIdentifier)
+    }
+
+    private func executeServerGroupDelete(
+        _ operation: ResourceDependencyResolver.PlannedOperation,
+        execution: BatchOperationExecution
+    ) async throws {
+        try await client.deleteServerGroup(id: operation.resourceIdentifier)
+    }
+
+    private func executeKeyPairDelete(
+        _ operation: ResourceDependencyResolver.PlannedOperation,
+        execution: BatchOperationExecution
+    ) async throws {
+        try await client.deleteKeyPair(name: operation.resourceIdentifier)
+    }
+
+    private func executeImageDelete(
+        _ operation: ResourceDependencyResolver.PlannedOperation,
+        execution: BatchOperationExecution
+    ) async throws {
+        try await client.deleteImage(id: operation.resourceIdentifier)
     }
 
     // MARK: - Helper Methods

--- a/Sources/Substation/BatchOperations/BatchOperationTypes.swift
+++ b/Sources/Substation/BatchOperations/BatchOperationTypes.swift
@@ -15,8 +15,17 @@ public enum BatchOperationType: Sendable, Hashable {
     case volumeBulkDelete(volumeIDs: [String])
     case floatingIPBulkCreate(configs: [FloatingIPCreateConfig])
     case floatingIPBulkAssign(assignments: [FloatingIPAssignment])
+    case floatingIPBulkDelete(floatingIPIDs: [String])
     case securityGroupBulkCreate(configs: [SecurityGroupCreateConfig])
+    case securityGroupBulkDelete(securityGroupIDs: [String])
     case networkInterfaceBulkAttach(operations: [NetworkInterfaceOperation])
+    case networkBulkDelete(networkIDs: [String])
+    case subnetBulkDelete(subnetIDs: [String])
+    case routerBulkDelete(routerIDs: [String])
+    case portBulkDelete(portIDs: [String])
+    case serverGroupBulkDelete(serverGroupIDs: [String])
+    case keyPairBulkDelete(keyPairNames: [String])
+    case imageBulkDelete(imageIDs: [String])
 
     public var description: String {
         switch self {
@@ -40,10 +49,28 @@ public enum BatchOperationType: Sendable, Hashable {
             return "Bulk create \(configs.count) floating IPs"
         case .floatingIPBulkAssign(let assignments):
             return "Bulk assign \(assignments.count) floating IPs"
+        case .floatingIPBulkDelete(let floatingIPIDs):
+            return "Bulk delete \(floatingIPIDs.count) floating IPs"
         case .securityGroupBulkCreate(let configs):
             return "Bulk create \(configs.count) security groups"
+        case .securityGroupBulkDelete(let securityGroupIDs):
+            return "Bulk delete \(securityGroupIDs.count) security groups"
         case .networkInterfaceBulkAttach(let operations):
             return "Bulk attach \(operations.count) network interfaces"
+        case .networkBulkDelete(let networkIDs):
+            return "Bulk delete \(networkIDs.count) networks"
+        case .subnetBulkDelete(let subnetIDs):
+            return "Bulk delete \(subnetIDs.count) subnets"
+        case .routerBulkDelete(let routerIDs):
+            return "Bulk delete \(routerIDs.count) routers"
+        case .portBulkDelete(let portIDs):
+            return "Bulk delete \(portIDs.count) ports"
+        case .serverGroupBulkDelete(let serverGroupIDs):
+            return "Bulk delete \(serverGroupIDs.count) server groups"
+        case .keyPairBulkDelete(let keyPairNames):
+            return "Bulk delete \(keyPairNames.count) key pairs"
+        case .imageBulkDelete(let imageIDs):
+            return "Bulk delete \(imageIDs.count) images"
         }
     }
 
@@ -69,10 +96,28 @@ public enum BatchOperationType: Sendable, Hashable {
             return max(1, configs.count / 20) // ~20 IPs per minute
         case .floatingIPBulkAssign(let assignments):
             return max(1, assignments.count / 15) // ~15 assignments per minute
+        case .floatingIPBulkDelete(let floatingIPIDs):
+            return max(1, floatingIPIDs.count / 20) // ~20 deletions per minute
         case .securityGroupBulkCreate(let configs):
             return max(1, configs.count / 10) // ~10 security groups per minute
+        case .securityGroupBulkDelete(let securityGroupIDs):
+            return max(1, securityGroupIDs.count / 15) // ~15 deletions per minute
         case .networkInterfaceBulkAttach(let operations):
             return max(1, operations.count / 12) // ~12 attachments per minute
+        case .networkBulkDelete(let networkIDs):
+            return max(1, networkIDs.count / 10) // ~10 deletions per minute
+        case .subnetBulkDelete(let subnetIDs):
+            return max(1, subnetIDs.count / 15) // ~15 deletions per minute
+        case .routerBulkDelete(let routerIDs):
+            return max(1, routerIDs.count / 10) // ~10 deletions per minute
+        case .portBulkDelete(let portIDs):
+            return max(1, portIDs.count / 20) // ~20 deletions per minute
+        case .serverGroupBulkDelete(let serverGroupIDs):
+            return max(1, serverGroupIDs.count / 15) // ~15 deletions per minute
+        case .keyPairBulkDelete(let keyPairNames):
+            return max(1, keyPairNames.count / 30) // ~30 deletions per minute
+        case .imageBulkDelete(let imageIDs):
+            return max(1, imageIDs.count / 8) // ~8 deletions per minute (slower due to image size)
         }
     }
 }

--- a/Sources/Substation/BatchOperations/ResourceDependencyResolver.swift
+++ b/Sources/Substation/BatchOperations/ResourceDependencyResolver.swift
@@ -17,6 +17,7 @@ actor ResourceDependencyResolver {
         case volume
         case floatingIP
         case securityGroup
+        case serverGroup
         case keyPair
         case image
         case flavor
@@ -39,6 +40,8 @@ actor ResourceDependencyResolver {
             case .floatingIP:
                 return [.network] // External network
             case .securityGroup:
+                return []
+            case .serverGroup:
                 return []
             case .keyPair:
                 return []
@@ -75,6 +78,8 @@ actor ResourceDependencyResolver {
                 return 7 // Then networks
             case .securityGroup:
                 return 8 // Security groups can be deleted late
+            case .serverGroup:
+                return 8 // Server groups can be deleted late
             case .keyPair, .image, .flavor:
                 return 9 // System resources last
             }
@@ -333,6 +338,33 @@ actor ResourceDependencyResolver {
 
         case .resourceCleanup(let criteria):
             operations = await buildResourceCleanupOperations(criteria)
+
+        case .networkBulkDelete(let networkIDs):
+            operations = await buildNetworkDeleteOperations(networkIDs)
+
+        case .subnetBulkDelete(let subnetIDs):
+            operations = await buildSubnetDeleteOperations(subnetIDs)
+
+        case .routerBulkDelete(let routerIDs):
+            operations = await buildRouterDeleteOperations(routerIDs)
+
+        case .portBulkDelete(let portIDs):
+            operations = await buildPortDeleteOperations(portIDs)
+
+        case .floatingIPBulkDelete(let floatingIPIDs):
+            operations = await buildFloatingIPDeleteOperations(floatingIPIDs)
+
+        case .securityGroupBulkDelete(let securityGroupIDs):
+            operations = await buildSecurityGroupDeleteOperations(securityGroupIDs)
+
+        case .serverGroupBulkDelete(let serverGroupIDs):
+            operations = await buildServerGroupDeleteOperations(serverGroupIDs)
+
+        case .keyPairBulkDelete(let keyPairNames):
+            operations = await buildKeyPairDeleteOperations(keyPairNames)
+
+        case .imageBulkDelete(let imageIDs):
+            operations = await buildImageDeleteOperations(imageIDs)
         }
 
         return operations
@@ -749,5 +781,122 @@ actor ResourceDependencyResolver {
         }
 
         return warnings
+    }
+
+    private func buildNetworkDeleteOperations(_ networkIDs: [String]) async -> [PlannedOperation] {
+        return networkIDs.enumerated().map { (index, networkID) in
+            PlannedOperation(
+                id: "network-delete-\(index)",
+                type: .network,
+                action: .delete,
+                resourceIdentifier: networkID,
+                dependencies: [],
+                estimatedDuration: OperationAction.delete.estimatedDurationSeconds
+            )
+        }
+    }
+
+    private func buildSubnetDeleteOperations(_ subnetIDs: [String]) async -> [PlannedOperation] {
+        return subnetIDs.enumerated().map { (index, subnetID) in
+            PlannedOperation(
+                id: "subnet-delete-\(index)",
+                type: .subnet,
+                action: .delete,
+                resourceIdentifier: subnetID,
+                dependencies: [],
+                estimatedDuration: OperationAction.delete.estimatedDurationSeconds
+            )
+        }
+    }
+
+    private func buildRouterDeleteOperations(_ routerIDs: [String]) async -> [PlannedOperation] {
+        return routerIDs.enumerated().map { (index, routerID) in
+            PlannedOperation(
+                id: "router-delete-\(index)",
+                type: .router,
+                action: .delete,
+                resourceIdentifier: routerID,
+                dependencies: [],
+                estimatedDuration: OperationAction.delete.estimatedDurationSeconds
+            )
+        }
+    }
+
+    private func buildPortDeleteOperations(_ portIDs: [String]) async -> [PlannedOperation] {
+        return portIDs.enumerated().map { (index, portID) in
+            PlannedOperation(
+                id: "port-delete-\(index)",
+                type: .port,
+                action: .delete,
+                resourceIdentifier: portID,
+                dependencies: [],
+                estimatedDuration: OperationAction.delete.estimatedDurationSeconds
+            )
+        }
+    }
+
+    private func buildFloatingIPDeleteOperations(_ floatingIPIDs: [String]) async -> [PlannedOperation] {
+        return floatingIPIDs.enumerated().map { (index, floatingIPID) in
+            PlannedOperation(
+                id: "floatingip-delete-\(index)",
+                type: .floatingIP,
+                action: .delete,
+                resourceIdentifier: floatingIPID,
+                dependencies: [],
+                estimatedDuration: OperationAction.delete.estimatedDurationSeconds
+            )
+        }
+    }
+
+    private func buildSecurityGroupDeleteOperations(_ securityGroupIDs: [String]) async -> [PlannedOperation] {
+        return securityGroupIDs.enumerated().map { (index, securityGroupID) in
+            PlannedOperation(
+                id: "securitygroup-delete-\(index)",
+                type: .securityGroup,
+                action: .delete,
+                resourceIdentifier: securityGroupID,
+                dependencies: [],
+                estimatedDuration: OperationAction.delete.estimatedDurationSeconds
+            )
+        }
+    }
+
+    private func buildServerGroupDeleteOperations(_ serverGroupIDs: [String]) async -> [PlannedOperation] {
+        return serverGroupIDs.enumerated().map { (index, serverGroupID) in
+            PlannedOperation(
+                id: "servergroup-delete-\(index)",
+                type: .serverGroup,
+                action: .delete,
+                resourceIdentifier: serverGroupID,
+                dependencies: [],
+                estimatedDuration: OperationAction.delete.estimatedDurationSeconds
+            )
+        }
+    }
+
+    private func buildKeyPairDeleteOperations(_ keyPairNames: [String]) async -> [PlannedOperation] {
+        return keyPairNames.enumerated().map { (index, keyPairName) in
+            PlannedOperation(
+                id: "keypair-delete-\(index)",
+                type: .keyPair,
+                action: .delete,
+                resourceIdentifier: keyPairName,
+                dependencies: [],
+                estimatedDuration: OperationAction.delete.estimatedDurationSeconds
+            )
+        }
+    }
+
+    private func buildImageDeleteOperations(_ imageIDs: [String]) async -> [PlannedOperation] {
+        return imageIDs.enumerated().map { (index, imageID) in
+            PlannedOperation(
+                id: "image-delete-\(index)",
+                type: .image,
+                action: .delete,
+                resourceIdentifier: imageID,
+                dependencies: [],
+                estimatedDuration: OperationAction.delete.estimatedDurationSeconds
+            )
+        }
     }
 }

--- a/Sources/Substation/Components/StatusListView.swift
+++ b/Sources/Substation/Components/StatusListView.swift
@@ -31,17 +31,20 @@ struct StatusListView<T: Sendable> {
     private let columns: [StatusListColumn<T>]
     private let getStatusIcon: (T) -> String
     private let filterItems: ([T], String?) -> [T]
+    private let getItemID: (T) -> String
 
     init(
         title: String,
         columns: [StatusListColumn<T>],
         getStatusIcon: @escaping (T) -> String,
-        filterItems: @escaping ([T], String?) -> [T]
+        filterItems: @escaping ([T], String?) -> [T],
+        getItemID: @escaping (T) -> String = { _ in "" }
     ) {
         self.title = title
         self.columns = columns
         self.getStatusIcon = getStatusIcon
         self.filterItems = filterItems
+        self.getItemID = getItemID
     }
 
     // MARK: - Main Draw Function
@@ -57,7 +60,9 @@ struct StatusListView<T: Sendable> {
         scrollOffset: Int,
         selectedIndex: Int,
         dataManager: DataManager? = nil,
-        virtualScrollManager: VirtualScrollManager<T>? = nil
+        virtualScrollManager: VirtualScrollManager<T>? = nil,
+        multiSelectMode: Bool = false,
+        selectedItems: Set<String> = []
     ) async {
         // Defensive bounds checking
         guard width > 10 && height > 10 else {
@@ -70,8 +75,11 @@ struct StatusListView<T: Sendable> {
         let surface = SwiftTUI.surface(from: screen)
         var components: [any Component] = []
 
-        // Title
-        let titleText = searchQuery.map { "\(title) (filtered: \($0))" } ?? title
+        // Title with multi-select indicator
+        var titleText = searchQuery.map { "\(title) (filtered: \($0))" } ?? title
+        if multiSelectMode {
+            titleText += " [MULTI-SELECT: \(selectedItems.count) selected]"
+        }
         components.append(Text(titleText).emphasis().bold().padding(EdgeInsets(top: 1, leading: 0, bottom: 0, trailing: 0)))
 
         // Header
@@ -85,7 +93,9 @@ struct StatusListView<T: Sendable> {
                 components: &components,
                 virtualScrollManager: virtualScrollManager,
                 selectedIndex: selectedIndex,
-                height: height
+                height: height,
+                multiSelectMode: multiSelectMode,
+                selectedItems: selectedItems
             )
         } else if let dataManager = dataManager, dataManager.isPaginationEnabled(for: title.lowercased()) {
             await renderWithPagination(
@@ -93,7 +103,9 @@ struct StatusListView<T: Sendable> {
                 dataManager: dataManager,
                 selectedIndex: selectedIndex,
                 height: height,
-                resourceKey: title.lowercased()
+                resourceKey: title.lowercased(),
+                multiSelectMode: multiSelectMode,
+                selectedItems: selectedItems
             )
         } else {
             await renderTraditional(
@@ -102,7 +114,9 @@ struct StatusListView<T: Sendable> {
                 searchQuery: searchQuery,
                 scrollOffset: scrollOffset,
                 selectedIndex: selectedIndex,
-                height: height
+                height: height,
+                multiSelectMode: multiSelectMode,
+                selectedItems: selectedItems
             )
         }
 
@@ -130,7 +144,9 @@ struct StatusListView<T: Sendable> {
         components: inout [any Component],
         virtualScrollManager: VirtualScrollManager<T>,
         selectedIndex: Int,
-        height: Int32
+        height: Int32,
+        multiSelectMode: Bool = false,
+        selectedItems: Set<String> = []
     ) async {
         let maxVisibleItems = max(1, Int(height) - 10)
         let renderableItems = virtualScrollManager.getRenderableItems(
@@ -144,7 +160,9 @@ struct StatusListView<T: Sendable> {
         } else {
             for (item, _, index) in renderableItems {
                 let isSelected = index == selectedIndex
-                let itemComponent = createItemComponent(item: item, isSelected: isSelected)
+                let itemID = getItemID(item)
+                let isMultiSelected = multiSelectMode && selectedItems.contains(itemID)
+                let itemComponent = createItemComponent(item: item, isSelected: isSelected, isMultiSelected: isMultiSelected, multiSelectMode: multiSelectMode)
                 components.append(itemComponent)
             }
 
@@ -159,7 +177,9 @@ struct StatusListView<T: Sendable> {
         dataManager: DataManager,
         selectedIndex: Int,
         height: Int32,
-        resourceKey: String
+        resourceKey: String,
+        multiSelectMode: Bool = false,
+        selectedItems: Set<String> = []
     ) async {
         let paginatedItems: [T] = await dataManager.getPaginatedItems(for: resourceKey, type: T.self)
 
@@ -173,7 +193,9 @@ struct StatusListView<T: Sendable> {
             for i in 0..<endIndex {
                 let item = paginatedItems[i]
                 let isSelected = i == selectedIndex
-                let itemComponent = createItemComponent(item: item, isSelected: isSelected)
+                let itemID = getItemID(item)
+                let isMultiSelected = multiSelectMode && selectedItems.contains(itemID)
+                let itemComponent = createItemComponent(item: item, isSelected: isSelected, isMultiSelected: isMultiSelected, multiSelectMode: multiSelectMode)
                 components.append(itemComponent)
             }
 
@@ -190,7 +212,9 @@ struct StatusListView<T: Sendable> {
         searchQuery: String?,
         scrollOffset: Int,
         selectedIndex: Int,
-        height: Int32
+        height: Int32,
+        multiSelectMode: Bool = false,
+        selectedItems: Set<String> = []
     ) async {
         let filteredItems = filterItems(items, searchQuery)
 
@@ -214,7 +238,9 @@ struct StatusListView<T: Sendable> {
             for i in startIndex..<endIndex {
                 let item = filteredItems[i]
                 let isSelected = i == selectedIndex
-                let itemComponent = createItemComponent(item: item, isSelected: isSelected)
+                let itemID = getItemID(item)
+                let isMultiSelected = multiSelectMode && selectedItems.contains(itemID)
+                let itemComponent = createItemComponent(item: item, isSelected: isSelected, isMultiSelected: isMultiSelected, multiSelectMode: multiSelectMode)
                 components.append(itemComponent)
             }
 
@@ -228,12 +254,18 @@ struct StatusListView<T: Sendable> {
 
     // MARK: - Item Component Creation
 
-    private func createItemComponent(item: T, isSelected: Bool) -> any Component {
+    private func createItemComponent(item: T, isSelected: Bool, isMultiSelected: Bool = false, multiSelectMode: Bool = false) -> any Component {
         var children: [any Component] = []
 
-        // Status icon
-        let statusIcon = getStatusIcon(item)
-        children.append(StatusIcon(status: statusIcon))
+        // In multi-select mode, replace status icon with checkbox
+        if multiSelectMode {
+            let checkbox = isMultiSelected ? "[X]" : "[ ]"
+            children.append(Text(checkbox).styled(isMultiSelected ? .accent : .secondary))
+        } else {
+            // Status icon when not in multi-select mode
+            let statusIcon = getStatusIcon(item)
+            children.append(StatusIcon(status: statusIcon))
+        }
 
         // Columns
         for column in columns {
@@ -241,7 +273,12 @@ struct StatusListView<T: Sendable> {
             let paddedValue = String(value.prefix(column.width))
                 .padding(toLength: column.width, withPad: " ", startingAt: 0)
 
-            let style = column.getStyle?(item) ?? (isSelected ? .accent : .secondary)
+            let style: TextStyle
+            if isMultiSelected {
+                style = .accent
+            } else {
+                style = column.getStyle?(item) ?? (isSelected ? .accent : .secondary)
+            }
             children.append(Text(" " + paddedValue).styled(style))
         }
 

--- a/Sources/Substation/Extensions/FloatingIP+StatusListView.swift
+++ b/Sources/Substation/Extensions/FloatingIP+StatusListView.swift
@@ -64,7 +64,8 @@ extension FloatingIPViews {
             },
             filterItems: { floatingIPs, query in
                 FilterUtils.filterFloatingIPs(floatingIPs, query: query)
-            }
+            },
+            getItemID: { floatingIP in floatingIP.id }
         )
     }
 }

--- a/Sources/Substation/Extensions/Image+StatusListView.swift
+++ b/Sources/Substation/Extensions/Image+StatusListView.swift
@@ -52,7 +52,8 @@ extension ImageViews {
             getStatusIcon: { _ in "active" },
             filterItems: { images, query in
                 FilterUtils.filterImages(images, query: query)
-            }
+            },
+            getItemID: { image in image.id }
         )
     }
 }

--- a/Sources/Substation/Extensions/KeyPair+StatusListView.swift
+++ b/Sources/Substation/Extensions/KeyPair+StatusListView.swift
@@ -29,7 +29,8 @@ extension KeyPairViews {
             getStatusIcon: { _ in "active" },
             filterItems: { keyPairs, query in
                 FilterUtils.filterKeyPairs(keyPairs, query: query)
-            }
+            },
+            getItemID: { keyPair in keyPair.name ?? "" }
         )
     }
 }

--- a/Sources/Substation/Extensions/Network+StatusListView.swift
+++ b/Sources/Substation/Extensions/Network+StatusListView.swift
@@ -51,6 +51,9 @@ extension NetworkViews {
             },
             filterItems: { networks, query in
                 FilterUtils.filterNetworks(networks, query: query)
+            },
+            getItemID: { network in
+                network.id
             }
         )
     }

--- a/Sources/Substation/Extensions/Port+StatusListView.swift
+++ b/Sources/Substation/Extensions/Port+StatusListView.swift
@@ -40,7 +40,8 @@ extension PortViews {
             },
             filterItems: { ports, query in
                 FilterUtils.filterPorts(ports, query: query)
-            }
+            },
+            getItemID: { port in port.id }
         )
     }
 }

--- a/Sources/Substation/Extensions/Router+StatusListView.swift
+++ b/Sources/Substation/Extensions/Router+StatusListView.swift
@@ -34,7 +34,8 @@ extension RouterViews {
             getStatusIcon: { _ in "active" },
             filterItems: { routers, query in
                 FilterUtils.filterRouters(routers, query: query)
-            }
+            },
+            getItemID: { router in router.id }
         )
     }
 }

--- a/Sources/Substation/Extensions/SecurityGroup+StatusListView.swift
+++ b/Sources/Substation/Extensions/SecurityGroup+StatusListView.swift
@@ -34,7 +34,8 @@ extension SecurityGroupViews {
             getStatusIcon: { _ in "active" },
             filterItems: { securityGroups, query in
                 FilterUtils.filterSecurityGroups(securityGroups, query: query)
-            }
+            },
+            getItemID: { securityGroup in securityGroup.id }
         )
     }
 }

--- a/Sources/Substation/Extensions/Server+StatusListView.swift
+++ b/Sources/Substation/Extensions/Server+StatusListView.swift
@@ -58,6 +58,9 @@ extension ServerViews {
             },
             filterItems: { servers, query in
                 FilterUtils.filterServers(servers, query: query)
+            },
+            getItemID: { server in
+                server.id
             }
         )
     }

--- a/Sources/Substation/Extensions/ServerGroup+StatusListView.swift
+++ b/Sources/Substation/Extensions/ServerGroup+StatusListView.swift
@@ -49,7 +49,8 @@ extension ServerGroupViews {
             getStatusIcon: { _ in "active" },
             filterItems: { serverGroups, query in
                 FilterUtils.filterServerGroups(serverGroups, query: query)
-            }
+            },
+            getItemID: { serverGroup in serverGroup.id }
         )
     }
 }

--- a/Sources/Substation/Extensions/Subnet+StatusListView.swift
+++ b/Sources/Substation/Extensions/Subnet+StatusListView.swift
@@ -35,7 +35,8 @@ extension SubnetViews {
             getStatusIcon: { _ in "active" },
             filterItems: { subnets, query in
                 FilterUtils.filterSubnets(subnets, query: query)
-            }
+            },
+            getItemID: { subnet in subnet.id }
         )
     }
 }

--- a/Sources/Substation/Extensions/Volume+StatusListView.swift
+++ b/Sources/Substation/Extensions/Volume+StatusListView.swift
@@ -58,6 +58,9 @@ extension VolumeViews {
             },
             filterItems: { volumes, query in
                 FilterUtils.filterVolumes(volumes, query: query)
+            },
+            getItemID: { volume in
+                volume.id
             }
         )
     }

--- a/Sources/Substation/Managers/InputHandler.swift
+++ b/Sources/Substation/Managers/InputHandler.swift
@@ -506,6 +506,19 @@ class InputHandler {
                 Logger.shared.logNavigation("\(tui.currentView)", to: ".swift")
                 tui.changeView(to: .swift)
             }
+        case Int32(24): // CTRL-X - Toggle multi-select mode
+            if !tui.currentView.isDetailView && tui.currentView.supportsMultiSelect {
+                Logger.shared.logUserAction("toggle_multi_select_mode", details: [
+                    "view": "\(tui.currentView)",
+                    "wasEnabled": tui.multiSelectMode
+                ])
+                handleToggleMultiSelectMode()
+            }
+        case Int32(77): // M - Manage security group rules
+            if tui.currentView == .securityGroups && !tui.currentView.isDetailView {
+                Logger.shared.logUserAction("manage_security_group_rules", details: ["selectedIndex": tui.selectedIndex])
+                await handleManageSecurityGroupRules(screen: screen)
+            }
         case Int32(109): // m - Volume Archives navigation
             if tui.currentView.isDetailView {
                 Logger.shared.logNavigation("\(tui.currentView)", to: ".volumeArchives", details: ["action": "exit_detail"])
@@ -553,8 +566,14 @@ class InputHandler {
         case Int32(339): // PAGE_UP
             Logger.shared.logUserAction("page_up", details: ["view": "\(tui.currentView)"])
             await handlePageUpKey()
-        case Int32(32): // SPACEBAR - Show details
-            if !tui.currentView.isDetailView {
+        case Int32(32): // SPACEBAR - Toggle item selection in multi-select mode or show details
+            if tui.multiSelectMode && !tui.currentView.isDetailView {
+                Logger.shared.logUserAction("toggle_multi_select_item", details: [
+                    "view": "\(tui.currentView)",
+                    "selectedIndex": tui.selectedIndex
+                ])
+                await handleMultiSelectToggle()
+            } else if !tui.currentView.isDetailView {
                 Logger.shared.logUserAction("open_detail_view", details: [
                     "view": "\(tui.currentView)",
                     "selectedIndex": tui.selectedIndex
@@ -647,11 +666,6 @@ class InputHandler {
         case Int32(90): // Z - Resize selected server
             Logger.shared.logUserAction("resize_server", details: ["selectedIndex": tui.selectedIndex])
             await handleResizeServer(screen: screen)
-        case Int32(77): // M - Manage security group rules
-            if tui.currentView == .securityGroups && !tui.currentView.isDetailView {
-                Logger.shared.logUserAction("manage_security_group_rules", details: ["selectedIndex": tui.selectedIndex])
-                await handleManageSecurityGroupRules(screen: screen)
-            }
         case Int32(65): // A - Context-sensitive: Attach security group to server OR network to server OR volume to server OR floating IP attach OR toggle auto-refresh interval
             if tui.currentView == .securityGroups && !tui.currentView.isDetailView {
                 Logger.shared.logUserAction("attach_security_group", details: ["selectedIndex": tui.selectedIndex])
@@ -873,10 +887,16 @@ class InputHandler {
         Logger.shared.logUserAction("escape_key_handling", details: [
             "view": "\(tui.currentView)",
             "isDetailView": tui.currentView.isDetailView,
-            "hasSearchQuery": tui.searchQuery != nil
+            "hasSearchQuery": tui.searchQuery != nil,
+            "multiSelectMode": tui.multiSelectMode
         ])
 
-        if tui.currentView == .help {
+        if tui.multiSelectMode {
+            Logger.shared.logUserAction("exit_multi_select_mode", details: ["selectedCount": tui.multiSelectedResourceIDs.count])
+            tui.multiSelectMode = false
+            tui.multiSelectedResourceIDs.removeAll()
+            tui.statusMessage = "Exited multi-select mode"
+        } else if tui.currentView == .help {
             Logger.shared.logNavigation(".help", to: "\(tui.previousView)")
             tui.changeView(to: tui.previousView, resetSelection: false)
         } else if tui.currentView.isDetailView {
@@ -1126,9 +1146,87 @@ class InputHandler {
         }
     }
 
+    // MARK: - Multi-Select Helper Methods
+    private func handleToggleMultiSelectMode() {
+        guard let tui = tui else { return }
+
+        tui.multiSelectMode.toggle()
+        if !tui.multiSelectMode {
+            tui.multiSelectedResourceIDs.removeAll()
+            tui.statusMessage = "Multi-select mode OFF"
+        } else {
+            tui.statusMessage = "Multi-select mode ON - Use SPACE to select items, CTRL-X to exit, DELETE to bulk delete"
+        }
+    }
+
+    private func handleMultiSelectToggle() async {
+        guard let tui = tui else { return }
+
+        let resourceID = getSelectedResourceID()
+        guard !resourceID.isEmpty else { return }
+
+        if tui.multiSelectedResourceIDs.contains(resourceID) {
+            tui.multiSelectedResourceIDs.remove(resourceID)
+            Logger.shared.logUserAction("deselect_resource", details: ["resourceID": resourceID])
+        } else {
+            tui.multiSelectedResourceIDs.insert(resourceID)
+            Logger.shared.logUserAction("select_resource", details: ["resourceID": resourceID])
+        }
+
+        tui.statusMessage = "\(tui.multiSelectedResourceIDs.count) items selected"
+    }
+
+    private func getSelectedResourceID() -> String {
+        guard let tui = tui else { return "" }
+
+        switch tui.currentView {
+        case .servers:
+            guard tui.selectedIndex < tui.cachedServers.count else { return "" }
+            return tui.cachedServers[tui.selectedIndex].id
+        case .volumes:
+            guard tui.selectedIndex < tui.cachedVolumes.count else { return "" }
+            return tui.cachedVolumes[tui.selectedIndex].id
+        case .networks:
+            guard tui.selectedIndex < tui.cachedNetworks.count else { return "" }
+            return tui.cachedNetworks[tui.selectedIndex].id
+        case .subnets:
+            guard tui.selectedIndex < tui.cachedSubnets.count else { return "" }
+            return tui.cachedSubnets[tui.selectedIndex].id
+        case .routers:
+            guard tui.selectedIndex < tui.cachedRouters.count else { return "" }
+            return tui.cachedRouters[tui.selectedIndex].id
+        case .ports:
+            guard tui.selectedIndex < tui.cachedPorts.count else { return "" }
+            return tui.cachedPorts[tui.selectedIndex].id
+        case .floatingIPs:
+            guard tui.selectedIndex < tui.cachedFloatingIPs.count else { return "" }
+            return tui.cachedFloatingIPs[tui.selectedIndex].id
+        case .securityGroups:
+            guard tui.selectedIndex < tui.cachedSecurityGroups.count else { return "" }
+            return tui.cachedSecurityGroups[tui.selectedIndex].id
+        case .serverGroups:
+            guard tui.selectedIndex < tui.cachedServerGroups.count else { return "" }
+            return tui.cachedServerGroups[tui.selectedIndex].id
+        case .keyPairs:
+            guard tui.selectedIndex < tui.cachedKeyPairs.count else { return "" }
+            return tui.cachedKeyPairs[tui.selectedIndex].name ?? ""
+        case .images:
+            guard tui.selectedIndex < tui.cachedImages.count else { return "" }
+            return tui.cachedImages[tui.selectedIndex].id
+        default:
+            return ""
+        }
+    }
+
     // MARK: - Server Action Methods
     private func handleDeleteKey(screen: OpaquePointer?) async {
         guard let tui = tui else { return }
+
+        // Handle bulk delete in multi-select mode
+        if tui.multiSelectMode && !tui.multiSelectedResourceIDs.isEmpty {
+            await handleBulkDelete(screen: screen)
+            return
+        }
 
         if tui.currentView == .servers && !tui.currentView.isDetailView {
             await tui.resourceOperations.deleteServer(screen: screen)
@@ -1392,6 +1490,91 @@ class InputHandler {
         if tui.currentView == .subnets && !tui.currentView.isDetailView {
             await tui.actions.manageSubnetRouterAttachment(screen: screen)
         }
+    }
+
+    private func handleBulkDelete(screen: OpaquePointer?) async {
+        guard let tui = tui else { return }
+
+        let itemCount = tui.multiSelectedResourceIDs.count
+        let resourceType = tui.currentView.title
+
+        // Show confirmation modal
+        let confirmed = await ConfirmationModal.show(
+            title: "Bulk Delete Confirmation",
+            message: "Delete \(itemCount) \(resourceType)?",
+            details: ["This action cannot be undone", "\(itemCount) items will be permanently deleted"],
+            screen: screen,
+            screenRows: tui.screenRows,
+            screenCols: tui.screenCols
+        )
+
+        guard confirmed else {
+            tui.statusMessage = "Bulk delete cancelled"
+            return
+        }
+
+        Logger.shared.logUserAction("bulk_delete_initiated", details: [
+            "view": "\(tui.currentView)",
+            "count": itemCount
+        ])
+
+        tui.statusMessage = "Deleting \(itemCount) \(resourceType)..."
+
+        let batchOperation: BatchOperationType
+
+        switch tui.currentView {
+        case .servers:
+            batchOperation = .serverBulkDelete(serverIDs: Array(tui.multiSelectedResourceIDs))
+        case .volumes:
+            batchOperation = .volumeBulkDelete(volumeIDs: Array(tui.multiSelectedResourceIDs))
+        case .networks:
+            batchOperation = .networkBulkDelete(networkIDs: Array(tui.multiSelectedResourceIDs))
+        case .subnets:
+            batchOperation = .subnetBulkDelete(subnetIDs: Array(tui.multiSelectedResourceIDs))
+        case .routers:
+            batchOperation = .routerBulkDelete(routerIDs: Array(tui.multiSelectedResourceIDs))
+        case .ports:
+            batchOperation = .portBulkDelete(portIDs: Array(tui.multiSelectedResourceIDs))
+        case .floatingIPs:
+            batchOperation = .floatingIPBulkDelete(floatingIPIDs: Array(tui.multiSelectedResourceIDs))
+        case .securityGroups:
+            batchOperation = .securityGroupBulkDelete(securityGroupIDs: Array(tui.multiSelectedResourceIDs))
+        case .serverGroups:
+            batchOperation = .serverGroupBulkDelete(serverGroupIDs: Array(tui.multiSelectedResourceIDs))
+        case .keyPairs:
+            batchOperation = .keyPairBulkDelete(keyPairNames: Array(tui.multiSelectedResourceIDs))
+        case .images:
+            batchOperation = .imageBulkDelete(imageIDs: Array(tui.multiSelectedResourceIDs))
+        default:
+            tui.statusMessage = "Bulk operations not supported for \(resourceType)"
+            return
+        }
+
+        let result = await tui.batchOperationManager.execute(batchOperation) { @Sendable progress in
+            Task { @MainActor [weak tui] in
+                tui?.statusMessage = "Deleting: \(progress.currentOperation)/\(progress.totalOperations) (\(Int(progress.completionPercentage * 100))%)"
+            }
+        }
+
+        if result.status == .completed {
+            tui.statusMessage = "Successfully deleted \(result.successfulOperations)/\(itemCount) \(resourceType)"
+            if result.failedOperations > 0 {
+                tui.statusMessage = tui.statusMessage! + " (\(result.failedOperations) failed)"
+            }
+        } else {
+            tui.statusMessage = "Bulk delete failed: \(result.error?.localizedDescription ?? "Unknown error")"
+        }
+
+        tui.multiSelectMode = false
+        tui.multiSelectedResourceIDs.removeAll()
+
+        await tui.dataManager.refreshAllData()
+
+        Logger.shared.logUserAction("bulk_delete_completed", details: [
+            "view": "\(tui.currentView)",
+            "successful": result.successfulOperations,
+            "failed": result.failedOperations
+        ])
     }
 
 

--- a/Sources/Substation/TUI.swift
+++ b/Sources/Substation/TUI.swift
@@ -82,6 +82,9 @@ final class TUI {
     internal var selectedServers: Set<String> = Set<String>()  // Selected server IDs for network attachment
     internal var attachedServerIds: Set<String> = Set<String>()  // Server IDs that have the selected resource attached
     internal var attachmentMode: AttachmentMode = .attach  // Current attachment mode (attach/detach)
+    // Multi-select mode state
+    internal var multiSelectMode: Bool = false  // Whether multi-select mode is enabled
+    internal var multiSelectedResourceIDs: Set<String> = Set<String>()  // IDs of selected resources in multi-select mode
     // Floating IP server management (single-select)
     internal var selectedServerId: String? = nil  // Selected server ID for floating IP management
     internal var attachedServerId: String? = nil  // Server ID that has the selected floating IP attached

--- a/Sources/Substation/Views/FloatingIPViews.swift
+++ b/Sources/Substation/Views/FloatingIPViews.swift
@@ -90,7 +90,8 @@ struct FloatingIPViews {
                                          width: Int32, height: Int32, cachedFloatingIPs: [FloatingIP],
                                          searchQuery: String?, scrollOffset: Int, selectedIndex: Int,
                                           cachedServers: [Server],
-                                         cachedPorts: [Port], cachedNetworks: [Network]) async {
+                                         cachedPorts: [Port], cachedNetworks: [Network],
+                                         multiSelectMode: Bool = false, selectedItems: Set<String> = []) async {
 
         let statusListView = createFloatingIPStatusListView(
             cachedServers: cachedServers,
@@ -106,7 +107,9 @@ struct FloatingIPViews {
             items: cachedFloatingIPs,
             searchQuery: searchQuery,
             scrollOffset: scrollOffset,
-            selectedIndex: selectedIndex
+            selectedIndex: selectedIndex,
+            multiSelectMode: multiSelectMode,
+            selectedItems: selectedItems
         )
     }
 

--- a/Sources/Substation/Views/ImageViews.swift
+++ b/Sources/Substation/Views/ImageViews.swift
@@ -9,7 +9,8 @@ struct ImageViews {
     @MainActor
     static func drawDetailedImageList(screen: OpaquePointer?, startRow: Int32, startCol: Int32,
                                     width: Int32, height: Int32, cachedImages: [Image],
-                                    searchQuery: String?, scrollOffset: Int, selectedIndex: Int) async {
+                                    searchQuery: String?, scrollOffset: Int, selectedIndex: Int,
+                                    multiSelectMode: Bool = false, selectedItems: Set<String> = []) async {
 
         let statusListView = createImageStatusListView()
         await statusListView.draw(
@@ -21,7 +22,9 @@ struct ImageViews {
             items: cachedImages,
             searchQuery: searchQuery,
             scrollOffset: scrollOffset,
-            selectedIndex: selectedIndex
+            selectedIndex: selectedIndex,
+            multiSelectMode: multiSelectMode,
+            selectedItems: selectedItems
         )
     }
 

--- a/Sources/Substation/Views/KeyPairViews.swift
+++ b/Sources/Substation/Views/KeyPairViews.swift
@@ -6,7 +6,8 @@ struct KeyPairViews {
     @MainActor
     static func drawDetailedKeyPairList(screen: OpaquePointer?, startRow: Int32, startCol: Int32,
                                       width: Int32, height: Int32, cachedKeyPairs: [KeyPair],
-                                      searchQuery: String?, scrollOffset: Int, selectedIndex: Int) async {
+                                      searchQuery: String?, scrollOffset: Int, selectedIndex: Int,
+                                      multiSelectMode: Bool = false, selectedItems: Set<String> = []) async {
 
         let statusListView = createKeyPairStatusListView()
         await statusListView.draw(
@@ -18,7 +19,9 @@ struct KeyPairViews {
             items: cachedKeyPairs,
             searchQuery: searchQuery,
             scrollOffset: scrollOffset,
-            selectedIndex: selectedIndex
+            selectedIndex: selectedIndex,
+            multiSelectMode: multiSelectMode,
+            selectedItems: selectedItems
         )
     }
 

--- a/Sources/Substation/Views/MainPanelView.swift
+++ b/Sources/Substation/Views/MainPanelView.swift
@@ -197,6 +197,15 @@ enum ViewMode: CaseIterable {
         }
     }
 
+    var supportsMultiSelect: Bool {
+        switch self {
+        case .servers, .volumes, .networks, .subnets, .routers, .ports, .floatingIPs, .securityGroups, .serverGroups, .keyPairs, .images:
+            return true
+        default:
+            return false
+        }
+    }
+
     var parentView: ViewMode {
         switch self {
         case .serverDetail: return .servers
@@ -290,23 +299,23 @@ struct MainPanelView {
             let telemetryActor = await tui.getTelemetryActor()
             await HealthDashboardView.draw(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, telemetryActor: telemetryActor, navigationState: tui.healthDashboardNavState, dataManager: tui.dataManager, performanceMonitor: tui.performanceMonitor)
         case .servers:
-            await ServerViews.drawDetailedServerList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedServers: tui.cachedServers, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex, cachedFlavors: tui.cachedFlavors, cachedImages: tui.cachedImages)
+            await ServerViews.drawDetailedServerList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedServers: tui.cachedServers, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex, cachedFlavors: tui.cachedFlavors, cachedImages: tui.cachedImages, multiSelectMode: tui.multiSelectMode, selectedItems: tui.multiSelectedResourceIDs)
         case .serverGroups:
-            await ServerGroupViews.drawDetailedServerGroupList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedServerGroups: tui.cachedServerGroups, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex)
+            await ServerGroupViews.drawDetailedServerGroupList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedServerGroups: tui.cachedServerGroups, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex, multiSelectMode: tui.multiSelectMode, selectedItems: tui.multiSelectedResourceIDs)
         case .networks:
-            await NetworkViews.drawDetailedNetworkList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedNetworks: tui.cachedNetworks, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex)
+            await NetworkViews.drawDetailedNetworkList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedNetworks: tui.cachedNetworks, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex, multiSelectMode: tui.multiSelectMode, selectedItems: tui.multiSelectedResourceIDs)
         case .securityGroups:
-            await SecurityGroupViews.drawDetailedSecurityGroupList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedSecurityGroups: tui.cachedSecurityGroups, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex)
+            await SecurityGroupViews.drawDetailedSecurityGroupList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedSecurityGroups: tui.cachedSecurityGroups, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex, multiSelectMode: tui.multiSelectMode, selectedItems: tui.multiSelectedResourceIDs)
         case .volumes:
-            await VolumeViews.drawDetailedVolumeList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedVolumes: tui.cachedVolumes, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex)
+            await VolumeViews.drawDetailedVolumeList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedVolumes: tui.cachedVolumes, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex, multiSelectMode: tui.multiSelectMode, selectedItems: tui.multiSelectedResourceIDs)
         case .volumeArchives:
             await VolumeArchiveViews.drawDetailedArchiveList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedVolumeSnapshots: tui.cachedVolumeSnapshots, cachedVolumeBackups: tui.cachedVolumeBackups, cachedImages: tui.cachedImages, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex)
         case .images:
-            await ImageViews.drawDetailedImageList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedImages: tui.cachedImages, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex)
+            await ImageViews.drawDetailedImageList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedImages: tui.cachedImages, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex, multiSelectMode: tui.multiSelectMode, selectedItems: tui.multiSelectedResourceIDs)
         case .flavors:
             await FlavorViews.drawDetailedFlavorList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedFlavors: tui.cachedFlavors, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex)
         case .keyPairs:
-            await KeyPairViews.drawDetailedKeyPairList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedKeyPairs: tui.cachedKeyPairs, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex)
+            await KeyPairViews.drawDetailedKeyPairList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedKeyPairs: tui.cachedKeyPairs, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex, multiSelectMode: tui.multiSelectMode, selectedItems: tui.multiSelectedResourceIDs)
         case .keyPairDetail:
             if let keyPair = tui.selectedResource as? KeyPair {
                 await KeyPairViews.drawKeyPairDetail(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, keyPair: keyPair, scrollOffset: tui.detailScrollOffset)
@@ -389,13 +398,13 @@ struct MainPanelView {
             await VolumeViews.drawVolumeCreate(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, formBuilderState: tui.volumeCreateFormState)
 
         case .subnets:
-            await SubnetViews.drawDetailedSubnetList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedSubnets: tui.cachedSubnets, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex)
+            await SubnetViews.drawDetailedSubnetList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedSubnets: tui.cachedSubnets, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex, multiSelectMode: tui.multiSelectMode, selectedItems: tui.multiSelectedResourceIDs)
         case .subnetDetail:
             if let subnet = tui.selectedResource as? Subnet {
                 await SubnetViews.drawSubnetDetail(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, subnet: subnet, scrollOffset: tui.detailScrollOffset)
             }
         case .ports:
-            await PortViews.drawDetailedPortList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedPorts: tui.cachedPorts, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex)
+            await PortViews.drawDetailedPortList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedPorts: tui.cachedPorts, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex, multiSelectMode: tui.multiSelectMode, selectedItems: tui.multiSelectedResourceIDs)
         case .portDetail:
             if let port = tui.selectedResource as? Port {
                 await PortViews.drawPortDetail(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, port: port, cachedNetworks: tui.cachedNetworks, cachedSubnets: tui.cachedSubnets, cachedSecurityGroups: tui.cachedSecurityGroups, scrollOffset: tui.detailScrollOffset)
@@ -403,7 +412,7 @@ struct MainPanelView {
         case .portCreate:
             await PortViews.drawPortCreateForm(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, portCreateForm: tui.portCreateForm, portCreateFormState: tui.portCreateFormState, cachedNetworks: tui.cachedNetworks, cachedSecurityGroups: tui.cachedSecurityGroups, cachedQoSPolicies: tui.cachedQoSPolicies, selectedIndex: tui.selectedIndex)
         case .routers:
-            await RouterViews.drawDetailedRouterList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedRouters: tui.cachedRouters, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex)
+            await RouterViews.drawDetailedRouterList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedRouters: tui.cachedRouters, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex, multiSelectMode: tui.multiSelectMode, selectedItems: tui.multiSelectedResourceIDs)
         case .routerDetail:
             if let selectedRouter = tui.selectedResource as? Router {
                 // Find the updated router from cached routers to get latest interface data
@@ -452,7 +461,7 @@ struct MainPanelView {
             tui.isFloatingIPViewRendering = true
             defer { tui.isFloatingIPViewRendering = false }
 
-            await FloatingIPViews.drawDetailedFloatingIPList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedFloatingIPs: tui.cachedFloatingIPs, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex, cachedServers: tui.cachedServers, cachedPorts: tui.cachedPorts, cachedNetworks: tui.cachedNetworks)
+            await FloatingIPViews.drawDetailedFloatingIPList(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, cachedFloatingIPs: tui.cachedFloatingIPs, searchQuery: tui.searchQuery, scrollOffset: tui.scrollOffset, selectedIndex: tui.selectedIndex, cachedServers: tui.cachedServers, cachedPorts: tui.cachedPorts, cachedNetworks: tui.cachedNetworks, multiSelectMode: tui.multiSelectMode, selectedItems: tui.multiSelectedResourceIDs)
         case .floatingIPDetail:
             if let floatingIP = tui.selectedResource as? FloatingIP {
                 await FloatingIPViews.drawFloatingIPDetail(screen: screen, startRow: mainStartRow, startCol: mainStartCol, width: mainWidth, height: mainHeight, floatingIP: floatingIP, cachedServers: tui.cachedServers, cachedPorts: tui.cachedPorts, cachedNetworks: tui.cachedNetworks, scrollOffset: tui.detailScrollOffset)

--- a/Sources/Substation/Views/MiscViews.swift
+++ b/Sources/Substation/Views/MiscViews.swift
@@ -118,6 +118,7 @@ struct MiscViews {
             "/: Search/filter current list",
             "a: Toggle auto-refresh (ON/OFF)",
             "c: Manual refresh",
+            "CTRL-X: Toggle multi-select mode (bulk operations)",
             "q/Q: Quit application",
             "?: Show help for current view",
             "@: Show about page",
@@ -140,6 +141,13 @@ struct MiscViews {
                     "DELETE: Delete selected server",
                     "Server States: ACTIVE, SHUTOFF, ERROR, BUILD",
                 ]),
+                ("Multi-Select Mode (CTRL-X)", [
+                    "CTRL-X: Toggle multi-select mode",
+                    "SPACE: Select/deselect items (in multi-select mode)",
+                    "DELETE: Bulk delete selected servers",
+                    "ESC: Exit multi-select mode",
+                    "Status icons show [ ] or [X] when in multi-select",
+                ]),
                 generalActions
             ]
 
@@ -153,6 +161,13 @@ struct MiscViews {
                     "P: Create volume snapshot",
                     "DELETE: Delete selected volume",
                     "Volume States: Available, In-use, Creating, Deleting",
+                ]),
+                ("Multi-Select Mode (CTRL-X)", [
+                    "CTRL-X: Toggle multi-select mode",
+                    "SPACE: Select/deselect items (in multi-select mode)",
+                    "DELETE: Bulk delete selected volumes",
+                    "ESC: Exit multi-select mode",
+                    "Status icons show [ ] or [X] when in multi-select",
                 ]),
                 generalActions
             ]
@@ -471,6 +486,7 @@ struct MiscViews {
                     "Color coding: Visual status indicators",
                     "Search and filtering: Quick resource location",
                     "Keyboard-driven: Full functionality without mouse",
+                    "Multi-select mode: Bulk operations (CTRL-X)",
                 ]),
                 generalActions
             ]

--- a/Sources/Substation/Views/NetworkViews.swift
+++ b/Sources/Substation/Views/NetworkViews.swift
@@ -8,7 +8,8 @@ struct NetworkViews {
                                       width: Int32, height: Int32, cachedNetworks: [Network],
                                       searchQuery: String?, scrollOffset: Int, selectedIndex: Int,
                                        dataManager: DataManager? = nil,
-                                      virtualScrollManager: VirtualScrollManager<Network>? = nil) async {
+                                      virtualScrollManager: VirtualScrollManager<Network>? = nil,
+                                      multiSelectMode: Bool = false, selectedItems: Set<String> = []) async {
 
         let statusListView = createNetworkStatusListView()
         await statusListView.draw(
@@ -22,7 +23,9 @@ struct NetworkViews {
             scrollOffset: scrollOffset,
             selectedIndex: selectedIndex,
             dataManager: dataManager,
-            virtualScrollManager: virtualScrollManager
+            virtualScrollManager: virtualScrollManager,
+            multiSelectMode: multiSelectMode,
+            selectedItems: selectedItems
         )
     }
 

--- a/Sources/Substation/Views/PortViews.swift
+++ b/Sources/Substation/Views/PortViews.swift
@@ -10,7 +10,8 @@ struct PortViews {
     @MainActor
     static func drawDetailedPortList(screen: OpaquePointer?, startRow: Int32, startCol: Int32,
                                     width: Int32, height: Int32, cachedPorts: [Port],
-                                    searchQuery: String?, scrollOffset: Int, selectedIndex: Int) async {
+                                    searchQuery: String?, scrollOffset: Int, selectedIndex: Int,
+                                    multiSelectMode: Bool = false, selectedItems: Set<String> = []) async {
 
         let statusListView = createPortStatusListView()
         await statusListView.draw(
@@ -22,7 +23,9 @@ struct PortViews {
             items: cachedPorts,
             searchQuery: searchQuery,
             scrollOffset: scrollOffset,
-            selectedIndex: selectedIndex
+            selectedIndex: selectedIndex,
+            multiSelectMode: multiSelectMode,
+            selectedItems: selectedItems
         )
     }
 

--- a/Sources/Substation/Views/RouterViews.swift
+++ b/Sources/Substation/Views/RouterViews.swift
@@ -6,7 +6,8 @@ struct RouterViews {
     @MainActor
     static func drawDetailedRouterList(screen: OpaquePointer?, startRow: Int32, startCol: Int32,
                                       width: Int32, height: Int32, cachedRouters: [Router],
-                                      searchQuery: String?, scrollOffset: Int, selectedIndex: Int) async {
+                                      searchQuery: String?, scrollOffset: Int, selectedIndex: Int,
+                                      multiSelectMode: Bool = false, selectedItems: Set<String> = []) async {
 
         let statusListView = createRouterStatusListView()
         await statusListView.draw(
@@ -18,7 +19,9 @@ struct RouterViews {
             items: cachedRouters,
             searchQuery: searchQuery,
             scrollOffset: scrollOffset,
-            selectedIndex: selectedIndex
+            selectedIndex: selectedIndex,
+            multiSelectMode: multiSelectMode,
+            selectedItems: selectedItems
         )
     }
 

--- a/Sources/Substation/Views/SecurityGroupManagementView.swift
+++ b/Sources/Substation/Views/SecurityGroupManagementView.swift
@@ -126,7 +126,8 @@ struct SecurityGroupViews {
     @MainActor
     static func drawDetailedSecurityGroupList(screen: OpaquePointer?, startRow: Int32, startCol: Int32,
                                              width: Int32, height: Int32, cachedSecurityGroups: [SecurityGroup],
-                                             searchQuery: String?, scrollOffset: Int, selectedIndex: Int) async {
+                                             searchQuery: String?, scrollOffset: Int, selectedIndex: Int,
+                                             multiSelectMode: Bool = false, selectedItems: Set<String> = []) async {
 
         let statusListView = createSecurityGroupStatusListView()
         await statusListView.draw(
@@ -138,7 +139,9 @@ struct SecurityGroupViews {
             items: cachedSecurityGroups,
             searchQuery: searchQuery,
             scrollOffset: scrollOffset,
-            selectedIndex: selectedIndex
+            selectedIndex: selectedIndex,
+            multiSelectMode: multiSelectMode,
+            selectedItems: selectedItems
         )
     }
 

--- a/Sources/Substation/Views/ServerGroupViews.swift
+++ b/Sources/Substation/Views/ServerGroupViews.swift
@@ -68,7 +68,8 @@ struct ServerGroupViews {
     @MainActor
     static func drawDetailedServerGroupList(screen: OpaquePointer?, startRow: Int32, startCol: Int32,
                                            width: Int32, height: Int32, cachedServerGroups: [ServerGroup],
-                                           searchQuery: String?, scrollOffset: Int, selectedIndex: Int) async {
+                                           searchQuery: String?, scrollOffset: Int, selectedIndex: Int,
+                                           multiSelectMode: Bool = false, selectedItems: Set<String> = []) async {
 
         let statusListView = createServerGroupStatusListView()
         await statusListView.draw(
@@ -80,7 +81,9 @@ struct ServerGroupViews {
             items: cachedServerGroups,
             searchQuery: searchQuery,
             scrollOffset: scrollOffset,
-            selectedIndex: selectedIndex
+            selectedIndex: selectedIndex,
+            multiSelectMode: multiSelectMode,
+            selectedItems: selectedItems
         )
     }
 

--- a/Sources/Substation/Views/ServerViews.swift
+++ b/Sources/Substation/Views/ServerViews.swift
@@ -41,7 +41,8 @@ struct ServerViews {
                                      width: Int32, height: Int32, cachedServers: [Server],
                                      searchQuery: String?, scrollOffset: Int, selectedIndex: Int,
                                       cachedFlavors: [Flavor], cachedImages: [Image],
-                                     dataManager: DataManager? = nil, virtualScrollManager: VirtualScrollManager<Server>? = nil) async {
+                                     dataManager: DataManager? = nil, virtualScrollManager: VirtualScrollManager<Server>? = nil,
+                                     multiSelectMode: Bool = false, selectedItems: Set<String> = []) async {
 
         let statusListView = createServerStatusListView(cachedFlavors: cachedFlavors, cachedImages: cachedImages)
         await statusListView.draw(
@@ -55,7 +56,9 @@ struct ServerViews {
             scrollOffset: scrollOffset,
             selectedIndex: selectedIndex,
             dataManager: dataManager,
-            virtualScrollManager: virtualScrollManager
+            virtualScrollManager: virtualScrollManager,
+            multiSelectMode: multiSelectMode,
+            selectedItems: selectedItems
         )
     }
 

--- a/Sources/Substation/Views/SubnetViews.swift
+++ b/Sources/Substation/Views/SubnetViews.swift
@@ -6,7 +6,8 @@ struct SubnetViews {
     @MainActor
     static func drawDetailedSubnetList(screen: OpaquePointer?, startRow: Int32, startCol: Int32,
                                       width: Int32, height: Int32, cachedSubnets: [Subnet],
-                                      searchQuery: String?, scrollOffset: Int, selectedIndex: Int) async {
+                                      searchQuery: String?, scrollOffset: Int, selectedIndex: Int,
+                                      multiSelectMode: Bool = false, selectedItems: Set<String> = []) async {
 
         let statusListView = createSubnetStatusListView()
         await statusListView.draw(
@@ -18,7 +19,9 @@ struct SubnetViews {
             items: cachedSubnets,
             searchQuery: searchQuery,
             scrollOffset: scrollOffset,
-            selectedIndex: selectedIndex
+            selectedIndex: selectedIndex,
+            multiSelectMode: multiSelectMode,
+            selectedItems: selectedItems
         )
     }
 

--- a/Sources/Substation/Views/VolumeViews.swift
+++ b/Sources/Substation/Views/VolumeViews.swift
@@ -11,7 +11,8 @@ struct VolumeViews {
                                      width: Int32, height: Int32, cachedVolumes: [Volume],
                                      searchQuery: String?, scrollOffset: Int, selectedIndex: Int,
                                       dataManager: DataManager? = nil,
-                                     virtualScrollManager: VirtualScrollManager<Volume>? = nil) async {
+                                     virtualScrollManager: VirtualScrollManager<Volume>? = nil,
+                                     multiSelectMode: Bool = false, selectedItems: Set<String> = []) async {
 
         let statusListView = createVolumeStatusListView()
         await statusListView.draw(
@@ -25,7 +26,9 @@ struct VolumeViews {
             scrollOffset: scrollOffset,
             selectedIndex: selectedIndex,
             dataManager: dataManager,
-            virtualScrollManager: virtualScrollManager
+            virtualScrollManager: virtualScrollManager,
+            multiSelectMode: multiSelectMode,
+            selectedItems: selectedItems
         )
     }
 

--- a/docs/architecture/technology-stack.md
+++ b/docs/architecture/technology-stack.md
@@ -257,7 +257,7 @@ Substation has exactly **one** external dependency:
 **Linux (Ubuntu/Debian):**
 
 ```bash
-sudo apt-get install -y libncurses6 libncurses-dev
+sudo apt install -y libncurses6 libncurses-dev
 ```
 
 **Linux (RHEL/CentOS/Fedora):**

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -62,8 +62,8 @@ sudo mv substation /usr/local/bin/
 
 ```bash
 # Install ncurses if not present (Ubuntu/Debian)
-sudo apt-get update
-sudo apt-get install -y libncurses6
+sudo apt update
+sudo apt install -y libncurses6
 
 # For RHEL/CentOS/Fedora
 # sudo dnf install -y ncurses-libs
@@ -112,14 +112,16 @@ swiftly use "6.1"
 
 ```bash
 # Install dependencies
-sudo apt-get update
-sudo apt-get install -y \
+sudo apt update
+sudo apt install -y \
     binutils \
+    build-essential \
     git \
     gnupg2 \
+    libc6-dev \
+    libcurl4-openssl-dev \
     libncurses-dev \
-    build-essential \
-    libc6-dev
+    libssl-dev
 
 # Install Swiftly
 curl -L https://swift-server.github.io/swiftly/swiftly-install.sh | bash
@@ -143,7 +145,8 @@ sudo dnf install -y \
     ncurses-devel \
     gcc \
     gcc-c++ \
-    glibc-devel
+    glibc-devel \
+    libcurl-devel
 
 # Install Swiftly
 curl -L https://swift-server.github.io/swiftly/swiftly-install.sh | bash
@@ -255,7 +258,7 @@ ls -l /usr/local/bin/substation
 
 ```bash
 # Ubuntu/Debian
-sudo apt-get install -y libncurses6
+sudo apt install -y libncurses6
 
 # RHEL/CentOS/Fedora
 sudo dnf install -y ncurses-libs
@@ -282,7 +285,7 @@ swiftly use 6.1
 
 ```bash
 # Ubuntu/Debian
-sudo apt-get install -y libncurses-dev
+sudo apt install -y libncurses-dev
 
 # RHEL/CentOS/Fedora
 sudo dnf install -y ncurses-devel

--- a/docs/reference/operators/keyboard-shortcuts.md
+++ b/docs/reference/operators/keyboard-shortcuts.md
@@ -41,6 +41,7 @@ Print this and tape it to your monitor (we won't judge).
 | `r` | Refresh | Refresh current view |
 | `a` | Auto-refresh Toggle | Cycle between 5s, 10s, 30s, 60s, off |
 | `/` | Search/Filter | Instant local filtering, no API calls |
+| `Ctrl-X` | Multi-Select Mode | Toggle multi-select mode for bulk operations |
 | `Esc` | Back/Cancel | Works everywhere, exits everything |
 | `q` | Quit | From main view only |
 
@@ -54,8 +55,29 @@ Print this and tape it to your monitor (we won't judge).
 | `Page Down` | Scroll down one page | - |
 | `Home` or `g` | Jump to top | Vim-style |
 | `End` or `G` | Jump to bottom | Vim-style |
-| `Space` | View details | Deep dive into a resource |
+| `Space` | View details (or toggle selection in multi-select) | Deep dive into a resource |
 | `Enter` | View details | Same as Space, because options |
+
+### Multi-Select Mode
+
+| Key | Action | Notes |
+|-----|--------|-------|
+| `Ctrl-X` | Toggle multi-select mode | Enter/exit multi-select mode |
+| `Space` | Toggle item selection | Select/deselect items (in multi-select mode) |
+| `Del` | Bulk delete | Delete all selected items (confirmation required) |
+| `Esc` | Exit multi-select | Cancel and clear selections |
+
+**Multi-Select Workflow:**
+
+1. Press `Ctrl-X` to enter multi-select mode
+2. Use arrow keys to navigate, `Space` to select/deselect items
+3. Status icons change to `[ ]` (unselected) or `[X]` (selected)
+4. Press `Del` to bulk delete selected items
+5. Press `Ctrl-X` or `Esc` to exit multi-select mode
+
+**Supported Views:**
+- Servers, Volumes, Networks, Subnets, Routers, Ports
+- Floating IPs, Security Groups, Server Groups, Key Pairs, Images
 
 ### Resource Actions
 
@@ -71,13 +93,14 @@ Print this and tape it to your monitor (we won't judge).
 | Key | Action | Notes |
 |-----|--------|-------|
 | `C` | Create server | Full server creation form |
-| `Del` | Delete server | Confirmation required |
+| `Del` | Delete server | Confirmation required (or bulk delete in multi-select) |
 | `S` | Start server | Power on |
 | `T` | Stop server | Graceful shutdown |
 | `R` | Restart server | Reboot (soft by default) |
 | `L` | View console logs | Last 100 lines |
 | `P` | Create snapshot | Create image from server |
 | `Z` | Resize server | Change flavor |
+| `Ctrl-X` | Multi-select mode | Bulk operations on multiple servers |
 
 ### Server Groups View (`g`)
 
@@ -109,12 +132,13 @@ Print this and tape it to your monitor (we won't judge).
 | Key | Action | Notes |
 |-----|--------|-------|
 | `C` | Create volume | Size, type, bootable option |
-| `Del` | Delete volume | Must be detached first |
+| `Del` | Delete volume | Must be detached first (or bulk delete in multi-select) |
 | `A` | Attach to server | Select server and device |
 | `X` | Detach from server | Unmount first! |
 | `P` | Create snapshot | Volume backup |
 | `M` | Manage snapshots | View/restore snapshots |
 | `E` | Extend volume size | Can't shrink, only grow |
+| `Ctrl-X` | Multi-select mode | Bulk operations on multiple volumes |
 
 ### Images View (`i`)
 
@@ -457,6 +481,7 @@ Actions:     C Del Space ? q    (Create, Delete, Details, Help, Quit)
 Search:      / z                (Local, Advanced)
 Refresh:     r c                (Refresh, Cache purge)
 Movement:    ↑↓ j k Page-Up/Dn  (List navigation)
+Bulk Ops:    Ctrl-X Space Del   (Multi-select, Select, Bulk delete)
 ```
 
 ### Emergency Shortcuts

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -707,7 +707,7 @@ chmod 600 ~/.substation/config.yaml
 
 ```bash
 # Ubuntu/Debian
-sudo apt-get install libncurses5
+sudo apt install libncurses6
 
 # RHEL/CentOS
 sudo yum install ncurses


### PR DESCRIPTION
This is the first bulk operation that will allow the application to multi-delete systems. Now, if a user presses CTRL-X the status screen will change to a multi-select window, and permit the user to select many items, which can then be used to initiate a delete. In the future this will be able to do like bulk snapshots, life-cycle management, and more. For now we do destructive things because that's easy.